### PR TITLE
Migrate requests to aiohttp

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           export PATH="$HOME/.local/share/mise/bin:$PATH"
           export PATH="$HOME/.local/bin:$PATH"
-          mise exec -- uv pip install pytest pytest-cov pytest-asyncio
+          mise exec -- uv pip install pytest pytest-cov pytest-asyncio aiohttp
           PYTHONPATH=. .venv/bin/python -m pytest --cov=. --cov-report=term > coverage.md || true
           mkdir -p wiki
           echo "# 🧪 Test Results" > wiki/TestResults.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 leagueofevents
 websockets
+aiohttp
 pytk
 obs-websocket-py
 pyinstaller

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,12 @@
 import asyncio
-import requests
+import aiohttp
 import websockets
 import json
 import logging
 
 ALLGAMEDATA_URL = "https://127.0.0.1:2999/liveclientdata/allgamedata"
 OBS_WS_URL = "ws://localhost:4455"
+HTTP_TIMEOUT = aiohttp.ClientTimeout(total=2)
 
 # ---- ロガーセットアップ ----
 logging.basicConfig(
@@ -70,73 +71,81 @@ async def trigger_obs_replay():
         logger.error("OBS連携失敗: %s", e)
 
 # ---- サモナーネーム自動取得 ----
-async def get_summoner_name():
+async def get_summoner_name(session: aiohttp.ClientSession):
     logger.info("サモナーネーム自動取得: ゲーム開始待機中…")
     while True:
         try:
-            resp = requests.get(ALLGAMEDATA_URL, verify=False, timeout=2)
-            data = resp.json()
+            async with session.get(ALLGAMEDATA_URL, timeout=HTTP_TIMEOUT) as resp:
+                data = await resp.json()
             if "activePlayer" in data and "summonerName" in data["activePlayer"]:
                 name = data["activePlayer"]["summonerName"]
                 logger.info("ゲーム開始検知！自分のサモナーネーム: %s", name)
                 return name
-        except Exception as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             logger.debug("サモナーネーム取得リトライ: %s", e)
+        except Exception as e:
+            logger.error("予期せぬエラー: %s", e)
         await asyncio.sleep(2)
 
 # ---- ゲーム終了検知 ----
-async def wait_for_game_end():
+async def wait_for_game_end(session: aiohttp.ClientSession):
     logger.info("ゲーム終了検知まで監視中…")
     while True:
         try:
-            resp = requests.get(ALLGAMEDATA_URL, verify=False, timeout=2)
-            data = resp.json()
+            async with session.get(ALLGAMEDATA_URL, timeout=HTTP_TIMEOUT) as resp:
+                data = await resp.json()
             if data.get("gameData", {}).get("gameEnded"):
                 logger.info("ゲーム終了検知！待ち受けに戻ります。")
                 break
-        except Exception as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             logger.warning("ゲーム終了監視中のAPIエラー: %s", e)
+        except Exception as e:
+            logger.error("予期せぬエラー: %s", e)
         await asyncio.sleep(2)
 
 # ---- メインループ ----
 async def main():
-    custom_manager = CustomEventManager()
-    history = []
+    connector = aiohttp.TCPConnector(ssl=False)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        custom_manager = CustomEventManager()
+        history = []
 
-    # イベントハンドラ
-    async def on_teamfight(event):
-        logger.info("🔥 集団戦検出！%s", event)
-        await trigger_obs_replay()
-    async def on_my_multikill(event):
-        logger.info("🏆 自分のマルチキル！%s", event)
-        await trigger_obs_replay()
-    async def on_my_death(event):
-        logger.info("💀 自分がデス…%s", event)
-        await trigger_obs_replay()
+        # イベントハンドラ
+        async def on_teamfight(event):
+            logger.info("🔥 集団戦検出！%s", event)
+            await trigger_obs_replay()
+        async def on_my_multikill(event):
+            logger.info("🏆 自分のマルチキル！%s", event)
+            await trigger_obs_replay()
+        async def on_my_death(event):
+            logger.info("💀 自分がデス…%s", event)
+            await trigger_obs_replay()
 
-    custom_manager.register("TeamFight", on_teamfight)
-    custom_manager.register("MyMultikill", on_my_multikill)
-    custom_manager.register("MyDeath", on_my_death)
+        custom_manager.register("TeamFight", on_teamfight)
+        custom_manager.register("MyMultikill", on_my_multikill)
+        custom_manager.register("MyDeath", on_my_death)
 
-    while True:
-        my_name = await get_summoner_name()
-        logger.info("自分のサモナーネーム: %s", my_name)
-
-        # ゲーム進行中ループ
         while True:
-            try:
-                resp = requests.get(ALLGAMEDATA_URL, verify=False, timeout=2)
-                data = resp.json()
-                history.append(data)
-                if len(history) > 10:
-                    history.pop(0)
-                await custom_manager.check_all(history, my_name)
-                if data.get("gameData", {}).get("gameEnded"):
-                    break
-            except Exception as e:
-                logger.warning("API取得失敗: %s", e)
-            await asyncio.sleep(1)
-        await wait_for_game_end()
+            my_name = await get_summoner_name(session)
+            logger.info("自分のサモナーネーム: %s", my_name)
+
+            # ゲーム進行中ループ
+            while True:
+                try:
+                    async with session.get(ALLGAMEDATA_URL, timeout=HTTP_TIMEOUT) as resp:
+                        data = await resp.json()
+                    history.append(data)
+                    if len(history) > 10:
+                        history.pop(0)
+                    await custom_manager.check_all(history, my_name)
+                    if data.get("gameData", {}).get("gameEnded"):
+                        break
+                except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                    logger.warning("API取得失敗: %s", e)
+                except Exception as e:
+                    logger.error("予期せぬエラー: %s", e)
+                await asyncio.sleep(1)
+            await wait_for_game_end(session)
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- async HTTP calls via `aiohttp`
- add `aiohttp` dependency and install during workflow

## Testing
- `python -m py_compile src/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd0963cb8832c850436eb1c047f31