### PR TITLE
Add configurable replay buffer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,13 @@ Once integrated with the Tauri app, the application will spawn this script
 automatically so you can manage the replay buffer from the GUI. Until then you
 can invoke the script manually from the project directory.
 
+### Replay buffer options
+
+When starting the replay buffer from the Tauri application, you can override the
+segment length and capture source:
+
+- `segment_seconds` (`-t`) – duration of each segment in seconds. Defaults to `6`.
+- `source` (`-s`) – `avfoundation` capture source string. Defaults to `"1:none"`.
+
+These values are passed directly to `ffmpeg_replaybuffer.sh` when it is spawned.
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -359,8 +359,18 @@ async fn get_saved_directory(_state: tauri::State<'_, AppStatusState>, obs_state
 }
 
 #[tauri::command]
-async fn start_ffmpeg_replay(state: tauri::State<'_, FfmpegState>) -> Result<(), String> {
+async fn start_ffmpeg_replay(
+    state: tauri::State<'_, FfmpegState>,
+    segment_seconds: Option<u32>,
+    source: Option<String>,
+) -> Result<(), String> {
     let mut proc = state.0.lock().unwrap();
+    if let Some(sec) = segment_seconds {
+        proc.set_segment_seconds(sec);
+    }
+    if let Some(src) = source {
+        proc.set_source(src);
+    }
     proc.start().await
 }
 
@@ -380,13 +390,28 @@ async fn save_ffmpeg_clip(state: tauri::State<'_, FfmpegState>) -> Result<(), St
 type SharedObsWsClient = Arc<Mutex<Option<ObsWsClient>>>;
 struct ObsWsState(SharedObsWsClient);
 
+
 struct FfmpegProcess {
     child: Option<Child>,
+    segment_seconds: u32,
+    source: String,
 }
 
 impl FfmpegProcess {
     fn new() -> Self {
-        Self { child: None }
+        Self {
+            child: None,
+            segment_seconds: 6,
+            source: "1:none".into(),
+        }
+    }
+
+    fn set_segment_seconds(&mut self, secs: u32) {
+        self.segment_seconds = secs;
+    }
+
+    fn set_source(&mut self, src: String) {
+        self.source = src;
     }
 
     async fn start(&mut self) -> Result<(), String> {
@@ -395,6 +420,10 @@ impl FfmpegProcess {
         }
         let child = Command::new("sh")
             .arg("./ffmpeg_replaybuffer.sh")
+            .arg("-t")
+            .arg(self.segment_seconds.to_string())
+            .arg("-s")
+            .arg(&self.source)
             .stdin(std::process::Stdio::piped())
             .spawn()
             .map_err(|e| e.to_string())?;

--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,12 @@
 
       <div class="button-group">
         <h2>🔁 リプレイバッファ</h2>
+        <label>秒数:
+          <input id="segmentSeconds" type="number" min="1" value="6" />
+        </label>
+        <label>ソース:
+          <input id="sourceInput" type="text" value="1:none" />
+        </label>
         <button id="btnReplayStart">開始</button>
         <button id="btnReplayStop">停止</button>
         <button id="btnReplaySave">保存</button>

--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,9 @@ window.addEventListener("DOMContentLoaded", () => {
   });
 
   document.getElementById('btnReplayStart').addEventListener('click', async () => {
-    await invoke('start_ffmpeg_replay');
+    const segmentSeconds = parseInt(document.getElementById('segmentSeconds').value, 10);
+    const source = document.getElementById('sourceInput').value;
+    await invoke('start_ffmpeg_replay', { segmentSeconds, source });
     logEvent("🔁 リプレイバッファを開始しました");
     updateStatus();
   });


### PR DESCRIPTION
## Summary
- pass `segment_seconds` and `source` to `ffmpeg_replaybuffer.sh`
- expose setters via the `start_ffmpeg_replay` command
- add UI fields for segment duration and source
- document the new options

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: system library `gio-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c616fc0b8832c90031484650f401c