### PR TITLE
Expand ffmpeg replay args

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ can invoke the script manually from the project directory.
 
 ### Replay buffer options
 
-When starting the replay buffer from the Tauri application, you can override the
-segment length and capture source:
+When starting the replay buffer from the Tauri application, you can override several
+`ffmpeg_replaybuffer.sh` options:
 
-- `segment_seconds` (`-t`) – duration of each segment in seconds. Defaults to `6`.
-- `source` (`-s`) – `avfoundation` capture source string. Defaults to `"1:none"`.
+- `segment_seconds` (`-t`) – length of each segment in seconds. Defaults to `6`.
+- `fps` (`-f`) – output frames per second. Defaults to `30`.
+- `video_source`/`audio_source` (`-s`) – combined as `<video>:<audio>` for the
+  `avfoundation` input. Defaults to `1:none`.
 
 These values are passed directly to `ffmpeg_replaybuffer.sh` when it is spawned.
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -362,14 +362,22 @@ async fn get_saved_directory(_state: tauri::State<'_, AppStatusState>, obs_state
 async fn start_ffmpeg_replay(
     state: tauri::State<'_, FfmpegState>,
     segment_seconds: Option<u32>,
-    source: Option<String>,
+    video_source: Option<String>,
+    audio_source: Option<String>,
+    fps: Option<u32>,
 ) -> Result<(), String> {
     let mut proc = state.0.lock().unwrap();
     if let Some(sec) = segment_seconds {
         proc.set_segment_seconds(sec);
     }
-    if let Some(src) = source {
-        proc.set_source(src);
+    if let Some(v) = video_source {
+        proc.set_video_source(v);
+    }
+    if let Some(a) = audio_source {
+        proc.set_audio_source(a);
+    }
+    if let Some(f) = fps {
+        proc.set_fps(f);
     }
     proc.start().await
 }
@@ -394,7 +402,9 @@ struct ObsWsState(SharedObsWsClient);
 struct FfmpegProcess {
     child: Option<Child>,
     segment_seconds: u32,
-    source: String,
+    video_source: String,
+    audio_source: String,
+    fps: u32,
 }
 
 impl FfmpegProcess {
@@ -402,7 +412,9 @@ impl FfmpegProcess {
         Self {
             child: None,
             segment_seconds: 6,
-            source: "1:none".into(),
+            video_source: "1".into(),
+            audio_source: "none".into(),
+            fps: 30,
         }
     }
 
@@ -410,8 +422,16 @@ impl FfmpegProcess {
         self.segment_seconds = secs;
     }
 
-    fn set_source(&mut self, src: String) {
-        self.source = src;
+    fn set_video_source(&mut self, src: String) {
+        self.video_source = src;
+    }
+
+    fn set_audio_source(&mut self, src: String) {
+        self.audio_source = src;
+    }
+
+    fn set_fps(&mut self, fps: u32) {
+        self.fps = fps;
     }
 
     async fn start(&mut self) -> Result<(), String> {
@@ -422,8 +442,10 @@ impl FfmpegProcess {
             .arg("./ffmpeg_replaybuffer.sh")
             .arg("-t")
             .arg(self.segment_seconds.to_string())
+            .arg("-f")
+            .arg(self.fps.to_string())
             .arg("-s")
-            .arg(&self.source)
+            .arg(format!("{}:{}", self.video_source, self.audio_source))
             .stdin(std::process::Stdio::piped())
             .spawn()
             .map_err(|e| e.to_string())?;

--- a/src/index.html
+++ b/src/index.html
@@ -28,8 +28,14 @@
         <label>秒数:
           <input id="segmentSeconds" type="number" min="1" value="6" />
         </label>
-        <label>ソース:
-          <input id="sourceInput" type="text" value="1:none" />
+        <label>FPS:
+          <input id="fpsInput" type="number" min="1" value="30" />
+        </label>
+        <label>映像ソース:
+          <input id="videoSourceInput" type="text" value="1" />
+        </label>
+        <label>音声ソース:
+          <input id="audioSourceInput" type="text" value="none" />
         </label>
         <button id="btnReplayStart">開始</button>
         <button id="btnReplayStop">停止</button>

--- a/src/main.js
+++ b/src/main.js
@@ -33,8 +33,10 @@ window.addEventListener("DOMContentLoaded", () => {
 
   document.getElementById('btnReplayStart').addEventListener('click', async () => {
     const segmentSeconds = parseInt(document.getElementById('segmentSeconds').value, 10);
-    const source = document.getElementById('sourceInput').value;
-    await invoke('start_ffmpeg_replay', { segmentSeconds, source });
+    const fps = parseInt(document.getElementById('fpsInput').value, 10);
+    const videoSource = document.getElementById('videoSourceInput').value;
+    const audioSource = document.getElementById('audioSourceInput').value;
+    await invoke('start_ffmpeg_replay', { segmentSeconds, fps, videoSource, audioSource });
     logEvent("🔁 リプレイバッファを開始しました");
     updateStatus();
   });


### PR DESCRIPTION
## Summary
- allow setting FPS and audio/video sources from the UI
- forward new options to `ffmpeg_replaybuffer.sh`
- document the additional parameters

## Testing
- `pnpm install`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684caa3633c4832ca46b764894b447c6