### PR TITLE
Enable persistent user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Start the LoL client before launching the app. The client exposes an API that th
 3. When a highlight occurs, press the **Clip** button (or configured hotkey) to save the OBS replay buffer.
 4. Saved videos can be opened from within the app for playback.
 5. Optionally choose to encode clips with ffmpeg for easier sharing.
+6. Use the **設定保存** button to persist your current options. They are loaded automatically on startup.
 
 ## `ffmpeg_replaybuffer.sh` (macOS)
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,9 @@ use tokio::io::AsyncWriteExt;
 use reqwest::Client;
 use std::collections::HashSet;
 
+mod settings;
+use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState};
+
 type WsType = WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
 
 pub struct ObsWsClient {
@@ -457,6 +460,37 @@ async fn get_saved_directory(_state: tauri::State<'_, AppStatusState>, obs_state
 }
 
 #[tauri::command]
+fn load_settings_cmd(state: tauri::State<SettingsState>) -> AppSettings {
+    state.0.lock().unwrap().clone()
+}
+
+#[tauri::command]
+async fn save_settings_cmd(
+    settings: AppSettings,
+    state: tauri::State<'_, SettingsState>,
+    path: tauri::State<'_, SettingsPath>,
+    status: tauri::State<'_, AppStatusState>,
+    ffmpeg: tauri::State<'_, FfmpegState>,
+) -> Result<(), String> {
+    {
+        let mut lock = state.0.lock().unwrap();
+        *lock = settings.clone();
+    }
+    {
+        let mut st = status.0.lock().unwrap();
+        st.recording_mode = settings.recording_mode.clone();
+    }
+    {
+        let mut proc = ffmpeg.0.lock().await;
+        proc.set_segment_seconds(settings.segment_seconds);
+        proc.set_video_source(settings.video_source.clone());
+        proc.set_audio_source(settings.audio_source.clone());
+        proc.set_fps(settings.fps);
+    }
+    save_settings(&path.0, &settings).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 async fn start_ffmpeg_replay(
     status_state: tauri::State<'_, AppStatusState>,
     state: tauri::State<'_, FfmpegState>,
@@ -624,18 +658,30 @@ struct AppStatusState(Arc<Mutex<AppStatus>>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let ctx = tauri::generate_context!();
+    let config_path = tauri::api::path::app_config_dir(&ctx.config())
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("settings.json");
+    let settings = load_settings(&config_path).unwrap_or_default();
 
     let status = Arc::new(Mutex::new(AppStatus {
         game_state: GameState::NotStarted,
         obs_state: ObsState::Disconnected,
-        recording_mode: RecordingMode::Obs,
+        recording_mode: settings.recording_mode.clone(),
         is_recording: false,
         replay_buffer_running: false,
     }));
 
     // グローバルで
     let obs_ws_client: SharedObsWsClient = Arc::new(Mutex::new(None));
-    let ffmpeg_process: SharedFfmpegProcess = Arc::new(AsyncMutex::new(FfmpegProcess::new()));
+    let mut ffmpeg_proc = FfmpegProcess::new();
+    ffmpeg_proc.set_segment_seconds(settings.segment_seconds);
+    ffmpeg_proc.set_video_source(settings.video_source.clone());
+    ffmpeg_proc.set_audio_source(settings.audio_source.clone());
+    ffmpeg_proc.set_fps(settings.fps);
+    let ffmpeg_process: SharedFfmpegProcess = Arc::new(AsyncMutex::new(ffmpeg_proc));
+    let settings_state = SettingsState(Arc::new(Mutex::new(settings)));
+    let settings_path_state = SettingsPath(config_path.clone());
 
     let status_clone = status.clone();
 
@@ -653,10 +699,14 @@ pub fn run() {
             start_ffmpeg_replay,
             stop_ffmpeg_replay,
             save_ffmpeg_clip,
+            load_settings_cmd,
+            save_settings_cmd,
             greet])
         .manage(AppStatusState(status.clone()))
         .manage(ObsWsState(obs_ws_client.clone()))
         .manage(FfmpegState(ffmpeg_process.clone()))
+        .manage(settings_state)
+        .manage(settings_path_state)
         .setup(move |_app| {
 
             // OBS WebSocketクライアントの初期化
@@ -732,7 +782,7 @@ pub fn run() {
             Ok(())
         })
         
-        .run(tauri::generate_context!())
+        .run(ctx)
         .expect("error while running tauri application");
 }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::RecordingMode;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppSettings {
+    pub recording_mode: RecordingMode,
+    pub segment_seconds: u32,
+    pub fps: u32,
+    pub video_source: String,
+    pub audio_source: String,
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            recording_mode: RecordingMode::Obs,
+            segment_seconds: 6,
+            fps: 30,
+            video_source: "1".into(),
+            audio_source: "none".into(),
+        }
+    }
+}
+
+pub fn load_settings(path: &Path) -> Option<AppSettings> {
+    fs::read_to_string(path).ok().and_then(|c| serde_json::from_str(&c).ok())
+}
+
+pub fn save_settings(path: &Path, settings: &AppSettings) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_string_pretty(settings).unwrap())
+}
+
+#[derive(Clone)]
+pub struct SettingsPath(pub PathBuf);
+
+pub struct SettingsState(pub std::sync::Arc<std::sync::Mutex<AppSettings>>);

--- a/src/index.html
+++ b/src/index.html
@@ -65,6 +65,7 @@
       <div class="button-group mb-4">
         <h2 class="h5 mb-3">🛠 ユーティリティ</h2>
         <button class="btn btn-outline-primary" id="btnGetDir">保存先を開く</button>
+        <button class="btn btn-outline-success ms-2" id="btnSaveSettings">設定保存</button>
       </div>
 
       <div class="log-container">

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,8 @@ window.addEventListener("DOMContentLoaded", () => {
   });
 });
 
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("DOMContentLoaded", async () => {
+  await loadSettings();
   // 各ボタンにイベントリスナーを設定
   document.getElementById('modeToggle').addEventListener('change', async (e) => {
     const mode = e.target.checked ? 'Shell' : 'Obs';
@@ -63,6 +64,10 @@ window.addEventListener("DOMContentLoaded", () => {
     logEvent(`📁 保存ディレクトリ: ${dir}`);
   });
 
+  document.getElementById('btnSaveSettings').addEventListener('click', async () => {
+    await saveSettings();
+  });
+
   setInterval(updateStatus, 1500);
   updateStatus();
 });
@@ -83,4 +88,25 @@ function logEvent(message) {
   const entry = document.createElement('li');
   entry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
   log.prepend(entry);
+}
+
+async function loadSettings() {
+  const s = await invoke('load_settings_cmd');
+  document.getElementById('segmentSeconds').value = s.segment_seconds;
+  document.getElementById('fpsInput').value = s.fps;
+  document.getElementById('videoSourceInput').value = s.video_source;
+  document.getElementById('audioSourceInput').value = s.audio_source;
+  document.getElementById('modeToggle').checked = s.recording_mode === 'Shell';
+}
+
+async function saveSettings() {
+  const settings = {
+    segment_seconds: parseInt(document.getElementById('segmentSeconds').value, 10),
+    fps: parseInt(document.getElementById('fpsInput').value, 10),
+    video_source: document.getElementById('videoSourceInput').value,
+    audio_source: document.getElementById('audioSourceInput').value,
+    recording_mode: document.getElementById('modeToggle').checked ? 'Shell' : 'Obs'
+  };
+  await invoke('save_settings_cmd', { settings });
+  logEvent('⚙️ 設定を保存しました');
 }


### PR DESCRIPTION
## Summary
- save configurable options to JSON in the user's config directory
- expose `load_settings_cmd` and `save_settings_cmd` commands
- add helper module for persisting settings
- load/save settings from the UI with a new button
- document the new feature in the README

## Testing
- `npm test` *(fails: Missing script)*
- `cargo check` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdc7174c8832ca9bc7e4ba60e7e31