### PR TITLE
Add device list dropdown

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -538,6 +538,67 @@ async fn save_ffmpeg_clip(state: tauri::State<'_, FfmpegState>) -> Result<(), St
     proc.save().await
 }
 
+#[derive(Serialize)]
+struct DeviceInfo {
+    index: i32,
+    name: String,
+}
+
+#[derive(Serialize)]
+struct DeviceList {
+    video: Vec<DeviceInfo>,
+    audio: Vec<DeviceInfo>,
+}
+
+#[tauri::command]
+async fn list_ffmpeg_devices() -> Result<DeviceList, String> {
+    let output = Command::new("ffmpeg")
+        .arg("-f")
+        .arg("avfoundation")
+        .arg("-list_devices")
+        .arg("true")
+        .arg("-i")
+        .arg("")
+        .output()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let mut video = Vec::new();
+    let mut audio = Vec::new();
+    let mut current = None::<&str>;
+
+    for line in stderr.lines() {
+        if line.contains("AVFoundation video devices") {
+            current = Some("video");
+            continue;
+        }
+        if line.contains("AVFoundation audio devices") {
+            current = Some("audio");
+            continue;
+        }
+        if let Some(kind) = current {
+            let trimmed = line.trim();
+            if let Some(start) = trimmed.find('[') {
+                if let Some(end) = trimmed[start + 1..].find(']') {
+                    let idx_str = &trimmed[start + 1..start + 1 + end];
+                    if let Ok(index) = idx_str.parse::<i32>() {
+                        let name = trimmed[start + 1 + end + 1..].trim();
+                        let info = DeviceInfo { index, name: name.to_string() };
+                        match kind {
+                            "video" => video.push(info),
+                            "audio" => audio.push(info),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(DeviceList { video, audio })
+}
+
 
 type SharedObsWsClient = Arc<Mutex<Option<ObsWsClient>>>;
 struct ObsWsState(SharedObsWsClient);
@@ -699,6 +760,7 @@ pub fn run() {
             start_ffmpeg_replay,
             stop_ffmpeg_replay,
             save_ffmpeg_clip,
+            list_ffmpeg_devices,
             load_settings_cmd,
             save_settings_cmd,
             greet])

--- a/src/index.html
+++ b/src/index.html
@@ -50,11 +50,11 @@
           </div>
           <div class="col-auto">
             <label class="form-label" for="videoSourceInput">映像ソース</label>
-            <input class="form-control" id="videoSourceInput" type="text" value="1" />
+            <select class="form-select" id="videoSourceInput"></select>
           </div>
           <div class="col-auto">
             <label class="form-label" for="audioSourceInput">音声ソース</label>
-            <input class="form-control" id="audioSourceInput" type="text" value="none" />
+            <select class="form-select" id="audioSourceInput"></select>
           </div>
         </div>
         <button class="btn btn-success me-2" id="btnReplayStart">開始</button>

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ window.addEventListener("DOMContentLoaded", () => {
 });
 
 window.addEventListener("DOMContentLoaded", async () => {
+  await loadDevices();
   await loadSettings();
   // 各ボタンにイベントリスナーを設定
   document.getElementById('modeToggle').addEventListener('change', async (e) => {
@@ -97,6 +98,26 @@ async function loadSettings() {
   document.getElementById('videoSourceInput').value = s.video_source;
   document.getElementById('audioSourceInput').value = s.audio_source;
   document.getElementById('modeToggle').checked = s.recording_mode === 'Shell';
+}
+
+async function loadDevices() {
+  const list = await invoke('list_ffmpeg_devices');
+  const vSel = document.getElementById('videoSourceInput');
+  const aSel = document.getElementById('audioSourceInput');
+  vSel.innerHTML = '';
+  list.video.forEach((d) => {
+    const opt = document.createElement('option');
+    opt.value = d.index;
+    opt.textContent = `[${d.index}] ${d.name}`;
+    vSel.appendChild(opt);
+  });
+  aSel.innerHTML = '';
+  list.audio.forEach((d) => {
+    const opt = document.createElement('option');
+    opt.value = d.index;
+    opt.textContent = `[${d.index}] ${d.name}`;
+    aSel.appendChild(opt);
+  });
 }
 
 async function saveSettings() {


### PR DESCRIPTION
## Summary
- expose `list_ffmpeg_devices` command in the Tauri backend
- populate video/audio source dropdowns in the UI
- switch source inputs to `<select>` elements

## Testing
- `cargo check` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce1266340832c993830c8fd63c36e