### PR TITLE
Fix multikill filter

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -799,8 +799,8 @@ pub fn run() {
                             "Multikill" => {
                                 // active_player == killer_name の場合、OBSに送信
                                 if let Some(killer_name) = &event.KillerName {
-                                    if killer_name.contains(all_data.activePlayer.summonerName.as_str()) {
-                                        continue; // 自分以外のマルチキルは無視
+                                    if !killer_name.contains(all_data.activePlayer.summonerName.as_str()) {
+                                        continue; // multikills by other players are ignored
                                     }
                                     match mode {
                                         RecordingMode::Obs => {


### PR DESCRIPTION
## Summary
- correct the multikill filter to ignore kills not by the active player

## Testing
- `pnpm install`
- `pnpm tauri build` *(fails: system library `gobject-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ce7f59a38832c955d34fa41895f03