### PR TITLE
Graceful stop for ffmpeg process

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2038,6 +2038,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "futures-util",
+ "nix",
  "reqwest",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,4 +27,5 @@ tokio-tungstenite = "0.26.2"
 futures-util = "0.3.31"
 reqwest = {version = "*", features = ["json", "rustls-tls"] }
 chrono = "0.4.41"
+nix = "0.30"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,8 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::net::TcpStream;
 use tokio::process::{Child, Command};
 use std::process::Stdio;
+use nix::sys::signal::{kill, Signal::SIGTERM};
+use nix::unistd::Pid;
 use tokio::io::AsyncWriteExt;
 use reqwest::Client;
 use std::collections::HashSet;
@@ -660,7 +662,17 @@ impl FfmpegProcess {
 
     async fn stop(&mut self) -> Result<(), String> {
         if let Some(mut child) = self.child.take() {
-            child.kill().await.map_err(|e| e.to_string())?;
+            let mut sent = false;
+            if let Some(stdin) = child.stdin.as_mut() {
+                if stdin.write_all(b"q").await.is_ok() {
+                    sent = true;
+                }
+            }
+            if !sent {
+                if let Some(id) = child.id() {
+                    kill(Pid::from_raw(id as i32), SIGTERM).map_err(|e| e.to_string())?;
+                }
+            }
             let _ = child.wait().await;
         }
         Ok(())


### PR DESCRIPTION
## Summary
- add `nix` dependency
- stop `ffmpeg_replaybuffer.sh` by writing `q` to stdin or sending SIGTERM

## Testing
- `cargo check` *(fails: glib-2.0 not found)*
- `./ffmpeg_replaybuffer.sh` *(fails: `hdiutil` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce7f58d44832c9584d6d0d07bbd5c