### PR TITLE
Auto-download ffmpeg for mac replay buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The frontend uses [Bootstrap](https://getbootstrap.com/) loaded via CDN for styl
 - **Rust**: install the latest stable toolchain via [rustup](https://rust-lang.org/tools/install).
 - **pnpm**: used for managing JavaScript dependencies.
 - **OBS Studio** with the **WebSocket** plugin enabled (v5 or later recommended).
-- **ffmpeg** in your `PATH` if you want to encode recordings.
+- No manual **ffmpeg** installation is required. The app downloads a suitable
+  binary to its local data directory on first run.
 - A running **League of Legends** client when using the tool.
 
 ## Build and Run
@@ -90,4 +91,11 @@ When starting the replay buffer from the Tauri application, you can override sev
   `avfoundation` input. Defaults to `1:none`.
 
 These values are passed directly to `ffmpeg_replaybuffer.sh` when it is spawned.
+
+### ffmpeg download location
+
+The application stores its own ffmpeg binary under the directory returned by
+`app_local_data_dir`. On macOS this is typically
+`~/Library/Application Support/<app>/ffmpeg/ffmpeg`. Replace the binary there to
+update or override the version shipped by default.
 

--- a/ffmpeg_replaybuffer.sh
+++ b/ffmpeg_replaybuffer.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+FFMPEG_BIN=${FFMPEG_BIN:-ffmpeg}
+
 FPS=30 BITRATE=20M SRC="1:none" SEG_S=6 WRAP=11 RAM_MB=512
 while getopts "f:b:s:t:n:r:h" o; do
   case $o in
@@ -26,7 +28,7 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-ffmpeg -f avfoundation -pixel_format nv12 -framerate $((FPS*2)) -i "$SRC" \
+"$FFMPEG_BIN" -f avfoundation -pixel_format nv12 -framerate $((FPS*2)) -i "$SRC" \
   -vf "fps=$FPS,format=yuv420p" \
   -c:v h264_videotoolbox -realtime 1 -bf 0 -b:v "$BITRATE" \
   -g "$GOP" -keyint_min "$GOP" -sc_threshold 0 \
@@ -42,7 +44,7 @@ while IFS= read -rsn1 k; do
   case "$k" in
     s)
       ts=$(date +%Y%m%d_%H%M%S)
-      ffmpeg -nostdin -y -live_start_index "$OFFSET" -i "$DIR/list.m3u8" \
+      "$FFMPEG_BIN" -nostdin -y -live_start_index "$OFFSET" -i "$DIR/list.m3u8" \
              -t "$DUR" -c copy -movflags +faststart "$HOME/Movies/replay_$ts.mp4"
       echo "saved $ts" ;;
     $'\x1b'|q) break ;;  # Esc または q で終了

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,11 +16,48 @@ use nix::unistd::Pid;
 use tokio::io::AsyncWriteExt;
 use reqwest::Client;
 use std::collections::HashSet;
+use std::path::PathBuf;
+use tokio::fs;
 
 mod settings;
 use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState};
 
 type WsType = WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
+
+async fn ensure_ffmpeg_path(config: &tauri::Config) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let mut dir = tauri::api::path::app_local_data_dir(config)
+        .ok_or("no data dir")?;
+    dir.push("ffmpeg");
+    fs::create_dir_all(&dir).await?;
+    let bin_name = if cfg!(windows) { "ffmpeg.exe" } else { "ffmpeg" };
+    let bin_path = dir.join(bin_name);
+    if bin_path.exists() {
+        return Ok(bin_path);
+    }
+
+    let url = if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-mac-arm64"
+    } else if cfg!(target_os = "macos") {
+        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-mac-x64"
+    } else if cfg!(target_os = "windows") {
+        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-win32-x64.exe"
+    } else {
+        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-linux-x64"
+    };
+
+    let bytes = reqwest::get(url).await?.bytes().await?;
+    fs::write(&bin_path, &bytes).await?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = fs::metadata(&bin_path).await?.permissions();
+        perm.set_mode(0o755);
+        fs::set_permissions(&bin_path, perm).await?;
+    }
+
+    Ok(bin_path)
+}
 
 pub struct ObsWsClient {
     ws: WsType,
@@ -578,8 +615,12 @@ struct DeviceList {
 }
 
 #[tauri::command]
-async fn list_ffmpeg_devices() -> Result<DeviceList, String> {
-    let output = Command::new("ffmpeg")
+async fn list_ffmpeg_devices(state: tauri::State<'_, FfmpegState>) -> Result<DeviceList, String> {
+    let ffmpeg_path = {
+        let proc = state.0.lock().await;
+        proc.ffmpeg_path.clone()
+    };
+    let output = Command::new(ffmpeg_path)
         .arg("-f")
         .arg("avfoundation")
         .arg("-list_devices")
@@ -633,6 +674,7 @@ struct ObsWsState(SharedObsWsClient);
 
 struct FfmpegProcess {
     child: Option<Child>,
+    ffmpeg_path: PathBuf,
     segment_seconds: u32,
     video_source: String,
     audio_source: String,
@@ -640,9 +682,10 @@ struct FfmpegProcess {
 }
 
 impl FfmpegProcess {
-    fn new() -> Self {
+    fn new(ffmpeg_path: PathBuf) -> Self {
         Self {
             child: None,
+            ffmpeg_path,
             segment_seconds: 6,
             video_source: "1".into(),
             audio_source: "none".into(),
@@ -656,6 +699,10 @@ impl FfmpegProcess {
 
     fn set_video_source(&mut self, src: String) {
         self.video_source = src;
+    }
+
+    fn set_ffmpeg_path(&mut self, path: PathBuf) {
+        self.ffmpeg_path = path;
     }
 
     fn set_audio_source(&mut self, src: String) {
@@ -672,6 +719,7 @@ impl FfmpegProcess {
         }
         let child = Command::new("sh")
             .arg("./ffmpeg_replaybuffer.sh")
+            .env("FFMPEG_BIN", &self.ffmpeg_path)
             .arg("-t")
             .arg(self.segment_seconds.to_string())
             .arg("-f")
@@ -793,6 +841,8 @@ pub fn run() {
         .join("settings.json");
     let settings = load_settings(&config_path).unwrap_or_default();
 
+    let ffmpeg_path = tauri::async_runtime::block_on(ensure_ffmpeg_path(&ctx.config())).expect("ffmpeg setup");
+
     let status = Arc::new(Mutex::new(AppStatus {
         game_state: GameState::NotStarted,
         obs_state: ObsState::Disconnected,
@@ -803,7 +853,7 @@ pub fn run() {
 
     // グローバルで
     let obs_ws_client: SharedObsWsClient = Arc::new(Mutex::new(None));
-    let mut ffmpeg_proc = FfmpegProcess::new();
+    let mut ffmpeg_proc = FfmpegProcess::new(ffmpeg_path);
     ffmpeg_proc.set_segment_seconds(settings.segment_seconds);
     ffmpeg_proc.set_video_source(settings.video_source.clone());
     ffmpeg_proc.set_audio_source(settings.audio_source.clone());


### PR DESCRIPTION
## Summary
- add environment variable support in `ffmpeg_replaybuffer.sh`
- download a per-platform ffmpeg binary into the app's local data dir on first run
- start the replay buffer script using the downloaded ffmpeg path
- document automatic ffmpeg handling and storage location

## Testing
- `cargo check` *(fails: glib-sys build failed due to missing system libraries)*

------
https://chatgpt.com/codex/tasks/task_e_684cf5b0f170832cbd7d487bef4948d0