### PR TITLE
Add metadata markers on seek bar

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -108,3 +108,21 @@ h1 {
   margin-top: 0.5rem;
   display: inline-block;
 }
+
+.event-marker-container {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.event-marker {
+  position: absolute;
+  bottom: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  transform: translateX(-50%);
+}
+

--- a/src/video.html
+++ b/src/video.html
@@ -34,6 +34,7 @@
         preload="auto"
         style="max-width: 720px;"
       ></video>
+      <div id="metadata" class="mt-3"></div>
     </main>
   </body>
 </html>

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,4 +1,28 @@
 const { convertFileSrc } = window.__TAURI__.core;
+function eventColor(name) {
+  switch (name) {
+    case "ChampionKill":
+      return "#dc3545";
+    case "Multikill":
+      return "#ffc107";
+    case "TurretKilled":
+      return "#0d6efd";
+    default:
+      return "#6c757d";
+  }
+}
+
+
+function formatEvent(e) {
+  switch (e.EventName) {
+    case 'ChampionKill':
+      return `${e.KillerName ?? 'Unknown'} → ${e.VictimName ?? 'Unknown'}`;
+    case 'Multikill':
+      return `Multikill x${e.KillStreak ?? ''}`;
+    default:
+      return e.EventName;
+  }
+}
 
 function init() {
   const params = new URLSearchParams(window.location.search);
@@ -6,6 +30,7 @@ function init() {
   if (!file) return;
 
   document.getElementById('fileName').textContent = file.split('/').pop();
+  const metadataEl = document.getElementById('metadata');
 
   const ext = file.split('.').pop().toLowerCase();
   let type = 'video/mp4';
@@ -17,6 +42,63 @@ function init() {
 
   const player = videojs('player');
   player.src({ src: convertFileSrc(file), type });
+  let markers;
+
+  function addMarkers() {
+    if (markers || events.length === 0 || !player.duration()) return;
+    const holder = player.el().querySelector(".vjs-progress-holder");
+    if (!holder) return;
+    holder.style.position = "relative";
+    markers = document.createElement("div");
+    markers.className = "event-marker-container";
+    holder.appendChild(markers);
+    events.forEach((e) => {
+      const m = document.createElement("span");
+      m.className = "event-marker";
+      m.style.left = `${(e.offset / player.duration()) * 100}%`;
+      m.style.backgroundColor = eventColor(e.EventName);
+      m.title = formatEvent(e);
+      markers.appendChild(m);
+    });
+  }
+
+
+  // Load metadata JSON if available
+  const metadataPath = file.replace(/\.[^/.]+$/, '.json');
+  let events = [];
+  fetch(convertFileSrc(metadataPath))
+    .then((r) => (r.ok ? r.json() : null))
+    .then((data) => {
+      if (data && Array.isArray(data.events)) {
+        events = data.events;
+      }
+        addMarkers();
+    })
+    .catch(() => {
+      /* ignore errors */
+    });
+
+  function update() {
+    if (events.length === 0) return;
+    const t = player.currentTime();
+    let current = null;
+    for (const e of events) {
+      if (e.offset <= t) {
+        current = e;
+      } else {
+        break;
+      }
+    }
+    if (current) {
+      metadataEl.textContent = `${formatEvent(current)} (@${current.offset.toFixed(
+        1
+      )}s)`;
+    }
+  }
+
+  player.on('loadedmetadata', addMarkers);
+  player.on('timeupdate', update);
+  player.on('seeked', update);
 }
 
 window.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- color-coded dot markers for each event along the progress bar
- script now overlays markers once metadata and video duration are known

## Testing
- `pnpm -v`


------
https://chatgpt.com/codex/tasks/task_e_684d1a8a5ee8832c8115a0f839c656bd