### PR TITLE
Show video details in list

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -524,8 +524,16 @@ async fn get_saved_directory(_state: tauri::State<'_, AppStatusState>, obs_state
     Ok(dir)
 }
 
+#[derive(Serialize)]
+struct SavedVideoInfo {
+    path: String,
+    name: String,
+    modified: String,
+    size: u64,
+}
+
 #[tauri::command]
-async fn list_saved_videos(obs_state: tauri::State<'_, ObsWsState>) -> Result<Vec<String>, String> {
+async fn list_saved_videos(obs_state: tauri::State<'_, ObsWsState>) -> Result<Vec<SavedVideoInfo>, String> {
     let resp = send_obs_request_wrapper(obs_state.0.clone(), "GetRecordDirectory").await?;
     let dir = resp
         .get("d")
@@ -540,7 +548,30 @@ async fn list_saved_videos(obs_state: tauri::State<'_, ObsWsState>) -> Result<Ve
         if path.is_file() {
             if let Some(ext) = path.extension() {
                 if ext == "mp4" || ext == "mkv" || ext == "mov" {
-                    files.push(path.to_string_lossy().to_string());
+                    let name = path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    let (modified, size) = match ent.metadata().await {
+                        Ok(meta) => {
+                            let modified = meta
+                                .modified()
+                                .ok()
+                                .map(|t| {
+                                    let dt: chrono::DateTime<chrono::Local> = t.into();
+                                    dt.format("%Y-%m-%d %H:%M:%S").to_string()
+                                })
+                                .unwrap_or_default();
+                            (modified, meta.len())
+                        }
+                        Err(_) => (String::new(), 0),
+                    };
+                    files.push(SavedVideoInfo {
+                        path: path.to_string_lossy().to_string(),
+                        name,
+                        modified,
+                        size,
+                    });
                 }
             }
         }

--- a/src/videos.html
+++ b/src/videos.html
@@ -22,7 +22,16 @@
     </nav>
     <main class="container py-4 app-container">
       <h1 class="mb-4 text-center">Saved Videos</h1>
-      <ul id="videoList" class="list-group"></ul>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Date</th>
+            <th>Size</th>
+          </tr>
+        </thead>
+        <tbody id="videoTableBody"></tbody>
+      </table>
     </main>
   </body>
 </html>

--- a/src/videos.js
+++ b/src/videos.js
@@ -2,16 +2,28 @@ const { invoke } = window.__TAURI__.core;
 
 async function loadVideos() {
   const list = await invoke('list_saved_videos');
-  const ul = document.getElementById('videoList');
-  ul.innerHTML = '';
-  list.forEach((path) => {
-    const li = document.createElement('li');
-    li.className = 'list-group-item';
-    const a = document.createElement('a');
-    a.href = `video.html?file=${encodeURIComponent(path)}`;
-    a.textContent = path.split('/').pop();
-    li.appendChild(a);
-    ul.appendChild(li);
+  const tbody = document.getElementById('videoTableBody');
+  tbody.innerHTML = '';
+  list.forEach((info) => {
+    const tr = document.createElement('tr');
+
+    const nameTd = document.createElement('td');
+    const link = document.createElement('a');
+    link.href = `video.html?file=${encodeURIComponent(info.path)}`;
+    link.textContent = info.name;
+    nameTd.appendChild(link);
+
+    const dateTd = document.createElement('td');
+    dateTd.textContent = info.modified;
+
+    const sizeTd = document.createElement('td');
+    sizeTd.textContent = `${(info.size / (1024 * 1024)).toFixed(1)} MB`;
+
+    tr.appendChild(nameTd);
+    tr.appendChild(dateTd);
+    tr.appendChild(sizeTd);
+
+    tbody.appendChild(tr);
   });
 }
 


### PR DESCRIPTION
## Summary
- show additional information for each video on the list screen
- return structured data from backend including date and size

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `gio-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3180c510832cac62978482ec3eed