### PR TITLE
Refactor Rust code into modules

### DIFF
--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -1,0 +1,209 @@
+use tokio::process::{Child, ChildStdout, Command};
+use tokio::io::{AsyncBufReadExt, BufReader, AsyncWriteExt};
+use std::sync::Arc;
+use tokio::sync::Mutex as AsyncMutex;
+use std::path::PathBuf;
+use nix::sys::signal::{kill, Signal::SIGTERM};
+use nix::unistd::Pid;
+use tokio_tungstenite; // for MaybeTlsStream? not needed but can't compile? Wait Ffmpeg doesn't use.
+use tokio; // not necessary? We'll rely on crate features.
+use dirs;
+
+use crate::lol::LolEvent;
+use serde::Serialize;
+use tokio::fs;
+
+/// Download or locate ffmpeg binary
+pub async fn ensure_ffmpeg_path(config: &tauri::Config) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let mut dir = tauri::api::path::app_local_data_dir(config)
+        .ok_or("no data dir")?;
+    dir.push("ffmpeg");
+    fs::create_dir_all(&dir).await?;
+    let bin_name = if cfg!(windows) { "ffmpeg.exe" } else { "ffmpeg" };
+    let bin_path = dir.join(bin_name);
+    if bin_path.exists() {
+        return Ok(bin_path);
+    }
+
+    let url = if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-mac-arm64"
+    } else if cfg!(target_os = "macos") {
+        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-mac-x64"
+    } else if cfg!(target_os = "windows") {
+        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-win32-x64.exe"
+    } else {
+        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-linux-x64"
+    };
+
+    let bytes = reqwest::get(url).await?.bytes().await?;
+    fs::write(&bin_path, &bytes).await?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = fs::metadata(&bin_path).await?.permissions();
+        perm.set_mode(0o755);
+        fs::set_permissions(&bin_path, perm).await?;
+    }
+
+    Ok(bin_path)
+}
+
+pub struct FfmpegProcess {
+    pub child: Option<Child>,
+    pub stdout: Option<BufReader<ChildStdout>>,
+    pub ffmpeg_path: PathBuf,
+    pub segment_seconds: u32,
+    pub video_source: String,
+    pub audio_source: String,
+    pub fps: u32,
+}
+
+impl FfmpegProcess {
+    pub fn new(ffmpeg_path: PathBuf) -> Self {
+        Self {
+            child: None,
+            stdout: None,
+            ffmpeg_path,
+            segment_seconds: 6,
+            video_source: "1".into(),
+            audio_source: "none".into(),
+            fps: 30,
+        }
+    }
+
+    pub fn set_segment_seconds(&mut self, secs: u32) {
+        self.segment_seconds = secs;
+    }
+
+    pub fn set_video_source(&mut self, src: String) {
+        self.video_source = src;
+    }
+
+    pub fn set_ffmpeg_path(&mut self, path: PathBuf) {
+        self.ffmpeg_path = path;
+    }
+
+    pub fn set_audio_source(&mut self, src: String) {
+        self.audio_source = src;
+    }
+
+    pub fn set_fps(&mut self, fps: u32) {
+        self.fps = fps;
+    }
+
+    pub async fn start(&mut self) -> Result<(), String> {
+        if self.child.is_some() {
+            return Ok(());
+        }
+        let mut child = Command::new("sh")
+            .arg("./ffmpeg_replaybuffer.sh")
+            .env("FFMPEG_BIN", &self.ffmpeg_path)
+            .arg("-t")
+            .arg(self.segment_seconds.to_string())
+            .arg("-f")
+            .arg(self.fps.to_string())
+            .arg("-s")
+            .arg(format!("{}:{}", self.video_source, self.audio_source))
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| e.to_string())?;
+        if let Some(out) = child.stdout.take() {
+            self.stdout = Some(BufReader::new(out));
+        }
+        self.child = Some(child);
+        Ok(())
+    }
+
+    pub async fn stop(&mut self) -> Result<(), String> {
+        if let Some(mut child) = self.child.take() {
+            let mut sent = false;
+            if let Some(stdin) = child.stdin.as_mut() {
+                if stdin.write_all(b"q").await.is_ok() {
+                    sent = true;
+                }
+            }
+            if !sent {
+                if let Some(id) = child.id() {
+                    kill(Pid::from_raw(id as i32), SIGTERM).map_err(|e| e.to_string())?;
+                }
+            }
+            let _ = child.wait().await;
+        }
+        self.stdout = None;
+        Ok(())
+    }
+
+    pub async fn save(&mut self) -> Result<PathBuf, String> {
+        if let Some(child) = &mut self.child {
+            if let Some(stdin) = child.stdin.as_mut() {
+                stdin.write_all(b"s").await.map_err(|e| e.to_string())?;
+            }
+        } else {
+            return Err("ffmpeg not running".into());
+        }
+
+        if let Some(stdout) = self.stdout.as_mut() {
+            let mut line = String::new();
+            loop {
+                line.clear();
+                let n = stdout
+                    .read_line(&mut line)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                if n == 0 {
+                    return Err("ffmpeg ended".into());
+                }
+                if let Some(ts) = line.strip_prefix("saved ") {
+                    let ts = ts.trim();
+                    let mut path = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+                    path.push("Movies");
+                    path.push(format!("replay_{}.mp4", ts));
+                    return Ok(path);
+                }
+            }
+        }
+        Err("no stdout".into())
+    }
+}
+
+pub type SharedFfmpegProcess = Arc<AsyncMutex<FfmpegProcess>>;
+pub struct FfmpegState(pub SharedFfmpegProcess);
+
+pub async fn write_clip_metadata(
+    path: &std::path::Path,
+    events: &[LolEvent],
+    clip_start: f64,
+) -> Result<(), String> {
+    #[derive(Serialize)]
+    struct EventWithOffset<'a> {
+        #[serde(flatten)]
+        event: &'a LolEvent,
+        offset: f64,
+    }
+
+    #[derive(Serialize)]
+    struct Metadata<'a> {
+        events: Vec<EventWithOffset<'a>>,
+    }
+
+    let events_with_offset = events
+        .iter()
+        .map(|e| EventWithOffset {
+            event: e,
+            offset: e.EventTime - clip_start,
+        })
+        .collect();
+
+    let data = Metadata {
+        events: events_with_offset,
+    };
+
+    let json_path = path.with_extension("json");
+    let contents = serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?;
+    fs::write(json_path, contents)
+        .await
+        .map_err(|e| e.to_string())
+}
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,347 +1,23 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 use tokio::sync::Mutex as AsyncMutex;
 use std::time::Duration;
-use serde_json::json;
-use tauri::async_runtime::spawn;
-use tokio_tungstenite::{connect_async, tungstenite::Message, WebSocketStream};
-use futures_util::{SinkExt, StreamExt};
-use tokio::net::TcpStream;
-use tokio::process::{Child, ChildStdout, Command};
-use tokio::io::{AsyncBufReadExt, BufReader, AsyncWriteExt};
-use std::process::Stdio;
-use nix::sys::signal::{kill, Signal::SIGTERM};
-use nix::unistd::Pid;
-use dirs;
-use reqwest::Client;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use tokio::process::Command;
 use tokio::fs;
+use reqwest::Client;
+use tauri::async_runtime::spawn;
 
 mod settings;
+mod lol;
+mod obs;
+mod ffmpeg;
+
 use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState};
-
-type WsType = WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
-
-async fn ensure_ffmpeg_path(config: &tauri::Config) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let mut dir = tauri::api::path::app_local_data_dir(config)
-        .ok_or("no data dir")?;
-    dir.push("ffmpeg");
-    fs::create_dir_all(&dir).await?;
-    let bin_name = if cfg!(windows) { "ffmpeg.exe" } else { "ffmpeg" };
-    let bin_path = dir.join(bin_name);
-    if bin_path.exists() {
-        return Ok(bin_path);
-    }
-
-    let url = if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
-        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-mac-arm64"
-    } else if cfg!(target_os = "macos") {
-        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-mac-x64"
-    } else if cfg!(target_os = "windows") {
-        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-win32-x64.exe"
-    } else {
-        "https://github.com/eugeneware/ffmpeg-static/releases/latest/download/ffmpeg-linux-x64"
-    };
-
-    let bytes = reqwest::get(url).await?.bytes().await?;
-    fs::write(&bin_path, &bytes).await?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perm = fs::metadata(&bin_path).await?.permissions();
-        perm.set_mode(0o755);
-        fs::set_permissions(&bin_path, perm).await?;
-    }
-
-    Ok(bin_path)
-}
-
-pub struct ObsWsClient {
-    ws: WsType,
-}
-
-impl ObsWsClient {
-    /// 接続＋Identifyまでセットアップ
-    pub async fn connect_and_identify(url: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let (mut ws_stream, _) = connect_async(url).await?;
-        // 1. Hello
-        let msg = ws_stream.next().await;
-        if let Some(Ok(Message::Text(text))) = msg {
-            let val: serde_json::Value = serde_json::from_str(&text)?;
-            if val.get("op").and_then(|v| v.as_u64()) != Some(0) {
-                return Err("No Hello from OBS".into());
-            }
-        } else {
-            return Err("Failed to receive Hello".into());
-        }
-        // 2. Identify
-        let identify = json!({
-            "op": 1,
-            "d": { "rpcVersion": 1, "authentication": null }
-        });
-        ws_stream.send(Message::Text(identify.to_string().into())).await?;
-        // 3. Identified
-        let msg = ws_stream.next().await;
-        if let Some(Ok(Message::Text(text))) = msg {
-            let val: serde_json::Value = serde_json::from_str(&text)?;
-            if val.get("op").and_then(|v| v.as_u64()) != Some(2) {
-                return Err("No Identified from OBS".into());
-            }
-        } else {
-            return Err("Failed to receive Identified".into());
-        }
-        Ok(ObsWsClient { ws: ws_stream })
-    }
-
-    /// 任意のコマンド送信
-    pub async fn send_command(&mut self, command: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let req = json!({
-            "op": 6,
-            "d": {
-                "requestType": command,
-                "requestId": "tauri-lol-obs-001"
-            }
-        });
-        self.ws.send(Message::Text(req.to_string().into())).await?;
-        Ok(())
-    }
-
-    /// 任意のコマンド送信してレスポンスを受け取る
-    pub async fn send_request(&mut self, command: &str) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-        let req = json!({
-            "op": 6,
-            "d": {
-                "requestType": command,
-                "requestId": "tauri-lol-obs-001"
-            }
-        });
-        self.ws.send(Message::Text(req.to_string().into())).await?;
-        if let Some(Ok(Message::Text(resp))) = self.ws.next().await {
-            let val: serde_json::Value = serde_json::from_str(&resp)?;
-            Ok(val)
-        } else {
-            Err("No response".into())
-        }
-    }
-}
-
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct AllGameData {
-    pub activePlayer: ActivePlayer,
-    pub allPlayers: Vec<Player>,
-    pub events: EventData,
-    pub gameData: GameData,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct ActivePlayer {
-    pub abilities: Abilities,
-    pub championStats: ChampionStats,
-    pub currentGold: f64,
-    pub fullRunes: FullRunes,
-    pub level: u32,
-    pub riotId: String,
-    pub riotIdGameName: String,
-    pub riotIdTagLine: String,
-    pub summonerName: String,
-    pub teamRelativeColors: bool,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct Abilities {
-    #[serde(rename = "Q")]
-    pub q: Option<Ability>,
-    #[serde(rename = "W")]
-    pub w: Option<Ability>,
-    #[serde(rename = "E")]
-    pub e: Option<Ability>,
-    #[serde(rename = "R")]
-    pub r: Option<Ability>,
-    #[serde(rename = "Passive")]
-    pub passive: Option<Ability>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct Ability {
-    #[serde(default)]
-    pub abilityLevel: Option<u32>,
-    pub displayName: String,
-    pub id: String,
-    pub rawDescription: String,
-    pub rawDisplayName: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct ChampionStats {
-    pub abilityHaste: f64,
-    pub abilityPower: f64,
-    pub armor: f64,
-    pub armorPenetrationFlat: f64,
-    pub armorPenetrationPercent: f64,
-    pub attackDamage: f64,
-    pub attackRange: f64,
-    pub attackSpeed: f64,
-    pub bonusArmorPenetrationPercent: f64,
-    pub bonusMagicPenetrationPercent: f64,
-    pub critChance: f64,
-    pub critDamage: f64,
-    pub currentHealth: f64,
-    pub healShieldPower: f64,
-    pub healthRegenRate: f64,
-    pub lifeSteal: f64,
-    pub magicLethality: f64,
-    pub magicPenetrationFlat: f64,
-    pub magicPenetrationPercent: f64,
-    pub magicResist: f64,
-    pub maxHealth: f64,
-    pub moveSpeed: f64,
-    pub omnivamp: f64,
-    pub physicalLethality: f64,
-    pub physicalVamp: f64,
-    pub resourceMax: f64,
-    pub resourceRegenRate: f64,
-    pub resourceType: String,
-    pub resourceValue: f64,
-    pub spellVamp: f64,
-    pub tenacity: f64,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct FullRunes {
-    pub generalRunes: Vec<Rune>,
-    pub keystone: Rune,
-    pub primaryRuneTree: RuneTree,
-    pub secondaryRuneTree: RuneTree,
-    pub statRunes: Vec<StatRune>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct Rune {
-    pub displayName: String,
-    pub id: u32,
-    pub rawDescription: String,
-    pub rawDisplayName: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct RuneTree {
-    pub displayName: String,
-    pub id: u32,
-    pub rawDescription: String,
-    pub rawDisplayName: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct StatRune {
-    pub id: u32,
-    pub rawDescription: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct Player {
-    pub championName: String,
-    pub isBot: bool,
-    pub isDead: bool,
-    pub items: Vec<Item>,
-    pub level: u32,
-    pub position: String,
-    pub rawChampionName: String,
-    pub rawSkinName: String,
-    pub respawnTimer: f64,
-    pub riotId: String,
-    pub riotIdGameName: String,
-    pub riotIdTagLine: String,
-    pub runes: PlayerRunes,
-    pub scores: Scores,
-    pub skinID: i32,
-    pub skinName: String,
-    pub summonerName: String,
-    pub summonerSpells: SummonerSpells,
-    pub team: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct Item {
-    pub canUse: bool,
-    pub consumable: bool,
-    pub count: u32,
-    pub displayName: String,
-    pub itemID: i32,
-    pub price: u32,
-    pub rawDescription: String,
-    pub rawDisplayName: String,
-    pub slot: u32,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct PlayerRunes {
-    pub keystone: Rune,
-    pub primaryRuneTree: RuneTree,
-    pub secondaryRuneTree: RuneTree,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct Scores {
-    pub assists: u32,
-    pub creepScore: u32,
-    pub deaths: u32,
-    pub kills: u32,
-    pub wardScore: f64,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct SummonerSpells {
-    pub summonerSpellOne: SummonerSpell,
-    pub summonerSpellTwo: SummonerSpell,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct SummonerSpell {
-    pub displayName: String,
-    pub rawDescription: String,
-    pub rawDisplayName: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct EventData {
-    #[serde(rename = "Events")]
-    pub events: Vec<LolEvent>,
-}
-
-#[derive(Debug, Deserialize, Clone, Serialize)]
-pub struct LolEvent {
-    pub EventID: i64,
-    pub EventName: String,
-    pub EventTime: f64,
-
-    // オプションなフィールドが多い！
-    pub Assisters: Option<Vec<String>>,
-    pub KillerName: Option<String>,
-    pub VictimName: Option<String>,
-    pub KillStreak: Option<u32>,
-    pub Recipient: Option<String>,
-    pub Result: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct GameData {
-    pub gameMode: String,
-    pub gameTime: f64,
-    pub mapName: String,
-    pub mapNumber: i32,
-    pub mapTerrain: String,
-}
-
-
-
-
-
-// OBS WebSocketの状態
+use lol::{AllGameData, LolEvent};
+use obs::{send_obs_command_wrapper, send_obs_request_wrapper, ObsWsState, SharedObsWsClient};
+use ffmpeg::{FfmpegProcess, FfmpegState, SharedFfmpegProcess, ensure_ffmpeg_path, write_clip_metadata};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 enum GameState {
@@ -359,7 +35,7 @@ enum ObsState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-enum RecordingMode {
+pub enum RecordingMode {
     Obs,
     Shell,
 }
@@ -372,8 +48,6 @@ struct AppStatus {
     is_recording: bool,
     replay_buffer_running: bool,
 }
-
-
 
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -723,236 +397,6 @@ async fn list_ffmpeg_devices(state: tauri::State<'_, FfmpegState>) -> Result<Dev
     Ok(DeviceList { video, audio })
 }
 
-
-type SharedObsWsClient = Arc<Mutex<Option<ObsWsClient>>>;
-struct ObsWsState(SharedObsWsClient);
-
-
-struct FfmpegProcess {
-    child: Option<Child>,
-    stdout: Option<BufReader<ChildStdout>>,
-    ffmpeg_path: PathBuf,
-    segment_seconds: u32,
-    video_source: String,
-    audio_source: String,
-    fps: u32,
-}
-
-impl FfmpegProcess {
-    fn new(ffmpeg_path: PathBuf) -> Self {
-        Self {
-            child: None,
-            stdout: None,
-            ffmpeg_path,
-            segment_seconds: 6,
-            video_source: "1".into(),
-            audio_source: "none".into(),
-            fps: 30,
-        }
-    }
-
-    fn set_segment_seconds(&mut self, secs: u32) {
-        self.segment_seconds = secs;
-    }
-
-    fn set_video_source(&mut self, src: String) {
-        self.video_source = src;
-    }
-
-    fn set_ffmpeg_path(&mut self, path: PathBuf) {
-        self.ffmpeg_path = path;
-    }
-
-    fn set_audio_source(&mut self, src: String) {
-        self.audio_source = src;
-    }
-
-    fn set_fps(&mut self, fps: u32) {
-        self.fps = fps;
-    }
-
-    async fn start(&mut self) -> Result<(), String> {
-        if self.child.is_some() {
-            return Ok(());
-        }
-        let mut child = Command::new("sh")
-            .arg("./ffmpeg_replaybuffer.sh")
-            .env("FFMPEG_BIN", &self.ffmpeg_path)
-            .arg("-t")
-            .arg(self.segment_seconds.to_string())
-            .arg("-f")
-            .arg(self.fps.to_string())
-            .arg("-s")
-            .arg(format!("{}:{}", self.video_source, self.audio_source))
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .spawn()
-            .map_err(|e| e.to_string())?;
-        if let Some(out) = child.stdout.take() {
-            self.stdout = Some(BufReader::new(out));
-        }
-        self.child = Some(child);
-        Ok(())
-    }
-
-    async fn stop(&mut self) -> Result<(), String> {
-        if let Some(mut child) = self.child.take() {
-            let mut sent = false;
-            if let Some(stdin) = child.stdin.as_mut() {
-                if stdin.write_all(b"q").await.is_ok() {
-                    sent = true;
-                }
-            }
-            if !sent {
-                if let Some(id) = child.id() {
-                    kill(Pid::from_raw(id as i32), SIGTERM).map_err(|e| e.to_string())?;
-                }
-            }
-            let _ = child.wait().await;
-        }
-        self.stdout = None;
-        Ok(())
-    }
-
-    async fn save(&mut self) -> Result<PathBuf, String> {
-        if let Some(child) = &mut self.child {
-            if let Some(stdin) = child.stdin.as_mut() {
-                stdin.write_all(b"s").await.map_err(|e| e.to_string())?;
-            }
-        } else {
-            return Err("ffmpeg not running".into());
-        }
-
-        if let Some(stdout) = self.stdout.as_mut() {
-            let mut line = String::new();
-            loop {
-                line.clear();
-                let n = stdout
-                    .read_line(&mut line)
-                    .await
-                    .map_err(|e| e.to_string())?;
-                if n == 0 {
-                    return Err("ffmpeg ended".into());
-                }
-                if let Some(ts) = line.strip_prefix("saved ") {
-                    let ts = ts.trim();
-                    let mut path = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-                    path.push("Movies");
-                    path.push(format!("replay_{}.mp4", ts));
-                    return Ok(path);
-                }
-            }
-        }
-        Err("no stdout".into())
-    }
-}
-
-type SharedFfmpegProcess = Arc<AsyncMutex<FfmpegProcess>>;
-struct FfmpegState(SharedFfmpegProcess);
-
-async fn write_clip_metadata(
-    path: &std::path::Path,
-    events: &[LolEvent],
-    clip_start: f64,
-) -> Result<(), String> {
-    #[derive(Serialize)]
-    struct EventWithOffset<'a> {
-        #[serde(flatten)]
-        event: &'a LolEvent,
-        offset: f64,
-    }
-
-    #[derive(Serialize)]
-    struct Metadata<'a> {
-        events: Vec<EventWithOffset<'a>>,
-    }
-
-    let events_with_offset = events
-        .iter()
-        .map(|e| EventWithOffset {
-            event: e,
-            offset: e.EventTime - clip_start,
-        })
-        .collect();
-
-    let data = Metadata {
-        events: events_with_offset,
-    };
-
-    let json_path = path.with_extension("json");
-    let contents = serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?;
-    tokio::fs::write(json_path, contents)
-        .await
-        .map_err(|e| e.to_string())
-}
-
-// 初回コマンド送信時
-async fn send_obs_command_wrapper(shared: SharedObsWsClient, command: &str) -> Result<(), String> {
-    let mut needs_connect = false;
-    {
-        let client_guard = shared.lock().unwrap();
-        needs_connect = client_guard.is_none();
-    }
-    if needs_connect {
-        let client = ObsWsClient::connect_and_identify("ws://127.0.0.1:4455")
-            .await
-            .map_err(|e| e.to_string())?;
-        let mut client_guard = shared.lock().unwrap();
-        *client_guard = Some(client);
-    }
-
-    // ここからが重要！
-    // Mutexをまたいだまま await しないために、一旦値を取り出して drop する
-    let mut client_opt = {
-        let mut guard = shared.lock().unwrap();
-        guard.take()
-    };
-    let result = if let Some(ref mut client) = client_opt {
-        client.send_command(command).await.map_err(|e| e.to_string())
-    } else {
-        Err("OBS WS Client not connected".into())
-    };
-
-    // 終わったら Mutex に値を戻す
-    {
-        let mut guard = shared.lock().unwrap();
-        *guard = client_opt;
-    }
-    result
-}
-
-// コマンド送信してレスポンスを受け取る
-async fn send_obs_request_wrapper(shared: SharedObsWsClient, command: &str) -> Result<serde_json::Value, String> {
-    let mut needs_connect = false;
-    {
-        let client_guard = shared.lock().unwrap();
-        needs_connect = client_guard.is_none();
-    }
-    if needs_connect {
-        let client = ObsWsClient::connect_and_identify("ws://127.0.0.1:4455")
-            .await
-            .map_err(|e| e.to_string())?;
-        let mut client_guard = shared.lock().unwrap();
-        *client_guard = Some(client);
-    }
-
-    let mut client_opt = {
-        let mut guard = shared.lock().unwrap();
-        guard.take()
-    };
-    let result = if let Some(ref mut client) = client_opt {
-        client.send_request(command).await.map_err(|e| e.to_string())
-    } else {
-        Err("OBS WS Client not connected".into())
-    };
-    {
-        let mut guard = shared.lock().unwrap();
-        *guard = client_opt;
-    }
-    result
-}
-
-
 struct AppStatusState(Arc<Mutex<AppStatus>>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -973,7 +417,6 @@ pub fn run() {
         replay_buffer_running: false,
     }));
 
-    // グローバルで
     let obs_ws_client: SharedObsWsClient = Arc::new(Mutex::new(None));
     let mut ffmpeg_proc = FfmpegProcess::new(ffmpeg_path);
     ffmpeg_proc.set_segment_seconds(settings.segment_seconds);
@@ -1011,37 +454,27 @@ pub fn run() {
         .manage(settings_state)
         .manage(settings_path_state)
         .setup(move |_app| {
-
-            // OBS WebSocketクライアントの初期化
             let obs_ws_client_clone = obs_ws_client.clone();
             let ffmpeg_process_clone = ffmpeg_process.clone();
 
-            // LoLのイベントをポーリングして処理するスレッド
             tauri::async_runtime::spawn(async move {
-                // LoLのイベントをポーリング
                 poll_lol_events(move |all_data: &AllGameData, new_events: Vec<LolEvent>| {
-                    // ゲーム状態の更新
                     let mut status = status_clone.lock().unwrap();
                     if status.game_state == GameState::NotStarted {
                         status.game_state = GameState::InProgress;
                     }
                     let mode = status.recording_mode.clone();
                     drop(status);
-                    
-                    // 現在操作中のプレイヤー情報をログに出力
-                    // println!("Active Player: {} ({})", all_data.active_player.summoner_name, all_data.active_player.champion_name);
 
-                    // 新しいイベントを処理
                     for event in new_events {
                         match event.EventName.as_str() {
                             "ChampionKill" => {
                                 println!("{} champion killed: {} by {}", event.EventTime, event.VictimName.as_deref().unwrap_or("Unknown"), event.KillerName.as_deref().unwrap_or("Unknown"));
                             }
                             "Multikill" => {
-                                // active_player == killer_name の場合、OBSに送信
                                 if let Some(killer_name) = &event.KillerName {
                                     if !killer_name.contains(all_data.activePlayer.summonerName.as_str()) {
-                                        continue; // multikills by other players are ignored
+                                        continue;
                                     }
                                     match mode {
                                         RecordingMode::Obs => {
@@ -1080,16 +513,8 @@ pub fn run() {
                                         }
                                     }
                                 }
-
-                            }
-                            "TurretKilled" => {
-                                
-                            }
-                            "DragonKill" => {
-                                
                             }
                             _ => {
-                                // 他のイベントは無視
                                 println!("Unhandled event: {} at {}", event.EventName, event.EventTime);
                             }
                         }
@@ -1099,18 +524,16 @@ pub fn run() {
 
             Ok(())
         })
-        
         .run(ctx)
         .expect("error while running tauri application");
 }
 
-/// LoLのイベントをポーリングしてコールバックを呼び出す
 async fn poll_lol_events<F>(mut callback: F)
 where
     F: FnMut(&AllGameData, Vec<LolEvent>) + Send + 'static,
 {
     let client = Client::builder()
-        .danger_accept_invalid_certs(true) // LoLのローカルAPIは自己署名証明書
+        .danger_accept_invalid_certs(true)
         .timeout(Duration::from_secs(1))
         .build()
         .unwrap();
@@ -1119,22 +542,16 @@ where
     println!("Starting LoL event polling...");
 
     loop {
-
         match client.get("https://127.0.0.1:2999/liveclientdata/allgamedata").send().await {
             Ok(response) => {
                 if let Ok(body) = response.text().await {
                     if let Ok(all_data) = serde_json::from_str::<AllGameData>(&body){
-                        // 新しいイベントのみを処理
                         let new_events: Vec<LolEvent> = all_data.clone().events.events.into_iter()
                             .filter(|event| !last_event_ids.contains(&event.EventID))
                             .collect();
-
                         if !new_events.is_empty() {
-                            // コールバックを呼び出す
                             println!("New events detected: {}", new_events.len());
                             callback(&all_data, new_events.clone());
-
-                            // 新しいイベントIDを記録
                             for event in &new_events {
                                 last_event_ids.insert(event.EventID);
                             }

--- a/src-tauri/src/lol.rs
+++ b/src-tauri/src/lol.rs
@@ -1,0 +1,209 @@
+// League of Legends data structures
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct AllGameData {
+    pub activePlayer: ActivePlayer,
+    pub allPlayers: Vec<Player>,
+    pub events: EventData,
+    pub gameData: GameData,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ActivePlayer {
+    pub abilities: Abilities,
+    pub championStats: ChampionStats,
+    pub currentGold: f64,
+    pub fullRunes: FullRunes,
+    pub level: u32,
+    pub riotId: String,
+    pub riotIdGameName: String,
+    pub riotIdTagLine: String,
+    pub summonerName: String,
+    pub teamRelativeColors: bool,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Abilities {
+    #[serde(rename = "Q")]
+    pub q: Option<Ability>,
+    #[serde(rename = "W")]
+    pub w: Option<Ability>,
+    #[serde(rename = "E")]
+    pub e: Option<Ability>,
+    #[serde(rename = "R")]
+    pub r: Option<Ability>,
+    #[serde(rename = "Passive")]
+    pub passive: Option<Ability>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Ability {
+    #[serde(default)]
+    pub abilityLevel: Option<u32>,
+    pub displayName: String,
+    pub id: String,
+    pub rawDescription: String,
+    pub rawDisplayName: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ChampionStats {
+    pub abilityHaste: f64,
+    pub abilityPower: f64,
+    pub armor: f64,
+    pub armorPenetrationFlat: f64,
+    pub armorPenetrationPercent: f64,
+    pub attackDamage: f64,
+    pub attackRange: f64,
+    pub attackSpeed: f64,
+    pub bonusArmorPenetrationPercent: f64,
+    pub bonusMagicPenetrationPercent: f64,
+    pub critChance: f64,
+    pub critDamage: f64,
+    pub currentHealth: f64,
+    pub healShieldPower: f64,
+    pub healthRegenRate: f64,
+    pub lifeSteal: f64,
+    pub magicLethality: f64,
+    pub magicPenetrationFlat: f64,
+    pub magicPenetrationPercent: f64,
+    pub magicResist: f64,
+    pub maxHealth: f64,
+    pub moveSpeed: f64,
+    pub omnivamp: f64,
+    pub physicalLethality: f64,
+    pub physicalVamp: f64,
+    pub resourceMax: f64,
+    pub resourceRegenRate: f64,
+    pub resourceType: String,
+    pub resourceValue: f64,
+    pub spellVamp: f64,
+    pub tenacity: f64,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct FullRunes {
+    pub generalRunes: Vec<Rune>,
+    pub keystone: Rune,
+    pub primaryRuneTree: RuneTree,
+    pub secondaryRuneTree: RuneTree,
+    pub statRunes: Vec<StatRune>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Rune {
+    pub displayName: String,
+    pub id: u32,
+    pub rawDescription: String,
+    pub rawDisplayName: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct RuneTree {
+    pub displayName: String,
+    pub id: u32,
+    pub rawDescription: String,
+    pub rawDisplayName: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct StatRune {
+    pub id: u32,
+    pub rawDescription: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Player {
+    pub championName: String,
+    pub isBot: bool,
+    pub isDead: bool,
+    pub items: Vec<Item>,
+    pub level: u32,
+    pub position: String,
+    pub rawChampionName: String,
+    pub rawSkinName: String,
+    pub respawnTimer: f64,
+    pub riotId: String,
+    pub riotIdGameName: String,
+    pub riotIdTagLine: String,
+    pub runes: PlayerRunes,
+    pub scores: Scores,
+    pub skinID: i32,
+    pub skinName: String,
+    pub summonerName: String,
+    pub summonerSpells: SummonerSpells,
+    pub team: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Item {
+    pub canUse: bool,
+    pub consumable: bool,
+    pub count: u32,
+    pub displayName: String,
+    pub itemID: i32,
+    pub price: u32,
+    pub rawDescription: String,
+    pub rawDisplayName: String,
+    pub slot: u32,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct PlayerRunes {
+    pub keystone: Rune,
+    pub primaryRuneTree: RuneTree,
+    pub secondaryRuneTree: RuneTree,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Scores {
+    pub assists: u32,
+    pub creepScore: u32,
+    pub deaths: u32,
+    pub kills: u32,
+    pub wardScore: f64,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct SummonerSpells {
+    pub summonerSpellOne: SummonerSpell,
+    pub summonerSpellTwo: SummonerSpell,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct SummonerSpell {
+    pub displayName: String,
+    pub rawDescription: String,
+    pub rawDisplayName: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct EventData {
+    #[serde(rename = "Events")]
+    pub events: Vec<LolEvent>,
+}
+
+#[derive(Debug, Deserialize, Clone, Serialize)]
+pub struct LolEvent {
+    pub EventID: i64,
+    pub EventName: String,
+    pub EventTime: f64,
+
+    pub Assisters: Option<Vec<String>>,
+    pub KillerName: Option<String>,
+    pub VictimName: Option<String>,
+    pub KillStreak: Option<u32>,
+    pub Recipient: Option<String>,
+    pub Result: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct GameData {
+    pub gameMode: String,
+    pub gameTime: f64,
+    pub mapName: String,
+    pub mapNumber: i32,
+    pub mapTerrain: String,
+}
+

--- a/src-tauri/src/obs.rs
+++ b/src-tauri/src/obs.rs
@@ -1,0 +1,142 @@
+use serde_json::json;
+use tokio_tungstenite::{connect_async, tungstenite::Message, WebSocketStream};
+use tokio::net::TcpStream;
+use futures_util::{SinkExt, StreamExt};
+use std::sync::{Arc, Mutex};
+
+pub type WsType = WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
+
+pub struct ObsWsClient {
+    ws: WsType,
+}
+
+impl ObsWsClient {
+    /// Connect to OBS WebSocket and perform Identify handshake
+    pub async fn connect_and_identify(url: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let (mut ws_stream, _) = connect_async(url).await?;
+        // 1. Hello
+        let msg = ws_stream.next().await;
+        if let Some(Ok(Message::Text(text))) = msg {
+            let val: serde_json::Value = serde_json::from_str(&text)?;
+            if val.get("op").and_then(|v| v.as_u64()) != Some(0) {
+                return Err("No Hello from OBS".into());
+            }
+        } else {
+            return Err("Failed to receive Hello".into());
+        }
+        // 2. Identify
+        let identify = json!({
+            "op": 1,
+            "d": { "rpcVersion": 1, "authentication": null }
+        });
+        ws_stream.send(Message::Text(identify.to_string().into())).await?;
+        // 3. Identified
+        let msg = ws_stream.next().await;
+        if let Some(Ok(Message::Text(text))) = msg {
+            let val: serde_json::Value = serde_json::from_str(&text)?;
+            if val.get("op").and_then(|v| v.as_u64()) != Some(2) {
+                return Err("No Identified from OBS".into());
+            }
+        } else {
+            return Err("Failed to receive Identified".into());
+        }
+        Ok(ObsWsClient { ws: ws_stream })
+    }
+
+    /// Send a command without waiting for response
+    pub async fn send_command(&mut self, command: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let req = json!({
+            "op": 6,
+            "d": {
+                "requestType": command,
+                "requestId": "tauri-lol-obs-001"
+            }
+        });
+        self.ws.send(Message::Text(req.to_string().into())).await?;
+        Ok(())
+    }
+
+    /// Send a command and wait for response
+    pub async fn send_request(&mut self, command: &str) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+        let req = json!({
+            "op": 6,
+            "d": {
+                "requestType": command,
+                "requestId": "tauri-lol-obs-001"
+            }
+        });
+        self.ws.send(Message::Text(req.to_string().into())).await?;
+        if let Some(Ok(Message::Text(resp))) = self.ws.next().await {
+            let val: serde_json::Value = serde_json::from_str(&resp)?;
+            Ok(val)
+        } else {
+            Err("No response".into())
+        }
+    }
+}
+
+pub type SharedObsWsClient = Arc<Mutex<Option<ObsWsClient>>>;
+pub struct ObsWsState(pub SharedObsWsClient);
+
+/// Send OBS command ensuring connection is established
+pub async fn send_obs_command_wrapper(shared: SharedObsWsClient, command: &str) -> Result<(), String> {
+    let mut needs_connect = false;
+    {
+        let client_guard = shared.lock().unwrap();
+        needs_connect = client_guard.is_none();
+    }
+    if needs_connect {
+        let client = ObsWsClient::connect_and_identify("ws://127.0.0.1:4455")
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut client_guard = shared.lock().unwrap();
+        *client_guard = Some(client);
+    }
+
+    let mut client_opt = {
+        let mut guard = shared.lock().unwrap();
+        guard.take()
+    };
+    let result = if let Some(ref mut client) = client_opt {
+        client.send_command(command).await.map_err(|e| e.to_string())
+    } else {
+        Err("OBS WS Client not connected".into())
+    };
+    {
+        let mut guard = shared.lock().unwrap();
+        *guard = client_opt;
+    }
+    result
+}
+
+/// Send OBS command and return the response
+pub async fn send_obs_request_wrapper(shared: SharedObsWsClient, command: &str) -> Result<serde_json::Value, String> {
+    let mut needs_connect = false;
+    {
+        let client_guard = shared.lock().unwrap();
+        needs_connect = client_guard.is_none();
+    }
+    if needs_connect {
+        let client = ObsWsClient::connect_and_identify("ws://127.0.0.1:4455")
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut client_guard = shared.lock().unwrap();
+        *client_guard = Some(client);
+    }
+
+    let mut client_opt = {
+        let mut guard = shared.lock().unwrap();
+        guard.take()
+    };
+    let result = if let Some(ref mut client) = client_opt {
+        client.send_request(command).await.map_err(|e| e.to_string())
+    } else {
+        Err("OBS WS Client not connected".into())
+    };
+    {
+        let mut guard = shared.lock().unwrap();
+        *guard = client_opt;
+    }
+    result
+}
+


### PR DESCRIPTION
## Summary
- break up growing `lib.rs` into `obs.rs`, `ffmpeg.rs` and `lol.rs`
- keep app entry point and commands in `lib.rs`

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 pc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d33cce728832cbfb9b9a8f8ad430c