### PR TITLE
Handle failed command output

### DIFF
--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -104,6 +104,9 @@ impl FfmpegProcess {
             .args(["attach", "-nomount", &format!("ram://{}", blocks)])
             .output()
             .map_err(|e| e.to_string())?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).to_string());
+        }
         let dev = String::from_utf8_lossy(&output.stdout).trim().to_string();
         Command::new("sudo")
             .args(["diskutil", "erasevolume", "HFS+", "RAMDisk", &dev])
@@ -207,7 +210,7 @@ impl FfmpegProcess {
         fs::create_dir_all(&out).await.map_err(|e| e.to_string())?;
         out.push(format!("replay_{}.mp4", ts));
 
-        Command::new(&self.ffmpeg_path)
+        let output = Command::new(&self.ffmpeg_path)
             .args([
                 "-nostdin",
                 "-y",
@@ -225,6 +228,9 @@ impl FfmpegProcess {
             ])
             .output()
             .map_err(|e| e.to_string())?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).to_string());
+        }
 
         Ok(out)
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -360,6 +360,9 @@ async fn list_ffmpeg_devices(state: tauri::State<'_, FfmpegState>) -> Result<Dev
         .output()
         .await
         .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).to_string());
+    }
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     let mut video = Vec::new();

--- a/src/settings.js
+++ b/src/settings.js
@@ -10,14 +10,22 @@ window.addEventListener("DOMContentLoaded", async () => {
     updateStatus();
   });
   document.getElementById('btnStart').addEventListener('click', async () => {
-    await invoke('start_recording');
-    logEvent("🎥 録画を開始しました");
+    try {
+      await invoke('start_recording');
+      logEvent("🎥 録画を開始しました");
+    } catch (e) {
+      logEvent(`⚠️ 録画開始に失敗しました: ${e}`);
+    }
     updateStatus();
   });
 
   document.getElementById('btnStop').addEventListener('click', async () => {
-    await invoke('stop_recording');
-    logEvent("⏹ 録画を停止しました");
+    try {
+      await invoke('stop_recording');
+      logEvent("⏹ 録画を停止しました");
+    } catch (e) {
+      logEvent(`⚠️ 録画停止に失敗しました: ${e}`);
+    }
     updateStatus();
   });
 
@@ -26,20 +34,32 @@ window.addEventListener("DOMContentLoaded", async () => {
     const fps = parseInt(document.getElementById('fpsInput').value, 10);
     const videoSource = document.getElementById('videoSourceInput').value;
     const audioSource = document.getElementById('audioSourceInput').value;
-    await invoke('start_ffmpeg_replay', { segmentSeconds, fps, videoSource, audioSource });
-    logEvent("🔁 リプレイバッファを開始しました");
+    try {
+      await invoke('start_ffmpeg_replay', { segmentSeconds, fps, videoSource, audioSource });
+      logEvent("🔁 リプレイバッファを開始しました");
+    } catch (e) {
+      logEvent(`⚠️ リプレイバッファの開始に失敗しました: ${e}`);
+    }
     updateStatus();
   });
 
   document.getElementById('btnReplayStop').addEventListener('click', async () => {
-    await invoke('stop_ffmpeg_replay');
-    logEvent("⏸ リプレイバッファを停止しました");
+    try {
+      await invoke('stop_ffmpeg_replay');
+      logEvent("⏸ リプレイバッファを停止しました");
+    } catch (e) {
+      logEvent(`⚠️ リプレイバッファの停止に失敗しました: ${e}`);
+    }
     updateStatus();
   });
 
   document.getElementById('btnReplaySave').addEventListener('click', async () => {
-    await invoke('save_ffmpeg_clip');
-    logEvent("💾 リプレイバッファを保存しました");
+    try {
+      await invoke('save_ffmpeg_clip');
+      logEvent("💾 リプレイバッファを保存しました");
+    } catch (e) {
+      logEvent(`⚠️ リプレイバッファの保存に失敗しました: ${e}`);
+    }
     updateStatus();
   });
 
@@ -84,23 +104,27 @@ async function loadSettings() {
 }
 
 async function loadDevices() {
-  const list = await invoke('list_ffmpeg_devices');
-  const vSel = document.getElementById('videoSourceInput');
-  const aSel = document.getElementById('audioSourceInput');
-  vSel.innerHTML = '';
-  list.video.forEach((d) => {
-    const opt = document.createElement('option');
-    opt.value = d.index;
-    opt.textContent = `[${d.index}] ${d.name}`;
-    vSel.appendChild(opt);
-  });
-  aSel.innerHTML = '';
-  list.audio.forEach((d) => {
-    const opt = document.createElement('option');
-    opt.value = d.index;
-    opt.textContent = `[${d.index}] ${d.name}`;
-    aSel.appendChild(opt);
-  });
+  try {
+    const list = await invoke('list_ffmpeg_devices');
+    const vSel = document.getElementById('videoSourceInput');
+    const aSel = document.getElementById('audioSourceInput');
+    vSel.innerHTML = '';
+    list.video.forEach((d) => {
+      const opt = document.createElement('option');
+      opt.value = d.index;
+      opt.textContent = `[${d.index}] ${d.name}`;
+      vSel.appendChild(opt);
+    });
+    aSel.innerHTML = '';
+    list.audio.forEach((d) => {
+      const opt = document.createElement('option');
+      opt.value = d.index;
+      opt.textContent = `[${d.index}] ${d.name}`;
+      aSel.appendChild(opt);
+    });
+  } catch (e) {
+    logEvent(`⚠️ デバイス情報の取得に失敗しました: ${e}`);
+  }
 }
 
 async function saveSettings() {


### PR DESCRIPTION
## Summary
- check success of shell commands in ffmpeg helpers
- propagate command failure in list_ffmpeg_devices
- show failures in UI event handlers

## Testing
- `cargo check` *(fails: gobject-2.0 library missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d475d8070832c8a7f368ce4dba16a