### PR TITLE
Remove nix and unused imports

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2038,7 +2038,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "futures-util",
- "nix",
  "reqwest",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,5 +27,4 @@ tokio-tungstenite = "0.26.2"
 futures-util = "0.3.31"
 reqwest = {version = "*", features = ["json", "rustls-tls"] }
 chrono = "0.4.41"
-nix = "0.30"
 

--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -2,8 +2,6 @@ use tauri::api::process::{Command, CommandChild};
 use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
 use std::path::PathBuf;
-use tokio_tungstenite; // maybe required elsewhere
-use tokio; // rely on crate features
 use dirs;
 
 use crate::lol::LolEvent;


### PR DESCRIPTION
## Summary
- remove `tokio_tungstenite` and `tokio` imports from `ffmpeg.rs`
- drop the unused `nix` dependency
- update lock file for the removed dependency

## Testing
- `cargo check` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d475ecb7c832c8954304e4e9dc421