### PR TITLE
Improve Ffmpeg process restart logic

### DIFF
--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -92,8 +92,13 @@ impl FfmpegProcess {
     }
 
     pub async fn start(&mut self) -> Result<(), String> {
+        if let Some(child) = self.child.as_mut() {
+            if child.try_wait().map_err(|e| e.to_string())?.is_none() {
+                return Ok(());
+            }
+        }
         if self.child.is_some() {
-            return Ok(());
+            self.stop().await?;
         }
         const WRAP: u32 = 11;
         const RAM_MB: u32 = 512;


### PR DESCRIPTION
## Summary
- check if an existing `CommandChild` is still running before starting ffmpeg
- clean up old resources when the process has exited

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `gio-sys` could not find system library)*

------
https://chatgpt.com/codex/tasks/task_e_684d47600bf8832cb5c8670584dfebe4