### PR TITLE
Switch ffmpeg temp output to /tmp path

### DIFF
--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -100,23 +100,12 @@ impl FfmpegProcess {
             self.stop().await?;
         }
         const WRAP: u32 = 11;
-        const RAM_MB: u32 = 512;
         const BITRATE: &str = "20M";
 
-        let blocks = RAM_MB * 2048;
-        let output = Command::new("hdiutil")
-            .args(["attach", "-nomount", &format!("ram://{}", blocks)])
-            .output()
-            .map_err(|e| e.to_string())?;
-        if !output.status.success() {
-            return Err(String::from_utf8_lossy(&output.stderr).to_string());
+        let dir = PathBuf::from("/tmp/lol_obs_clip/replay");
+        if dir.exists() {
+            fs::remove_dir_all(&dir).await.map_err(|e| e.to_string())?;
         }
-        let dev = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        Command::new("sudo")
-            .args(["diskutil", "erasevolume", "HFS+", "RAMDisk", &dev])
-            .status()
-            .map_err(|e| e.to_string())?;
-        let dir = PathBuf::from("/Volumes/RAMDisk/replay");
         fs::create_dir_all(&dir).await.map_err(|e| e.to_string())?;
 
         let gop = self.fps * self.segment_seconds;
@@ -171,7 +160,7 @@ impl FfmpegProcess {
             .map_err(|e| e.to_string())?;
 
         self.child = Some(child);
-        self.ram_device = Some(dev);
+        self.ram_device = None;
         self.ram_dir = Some(dir);
         Ok(())
     }
@@ -181,12 +170,6 @@ impl FfmpegProcess {
             let _ = child.kill();
         }
         if let Some(dir) = &self.ram_dir {
-            let _ = Command::new("diskutil")
-                .args(["eject", "/Volumes/RAMDisk"])
-                .status();
-            if let Some(dev) = &self.ram_device {
-                let _ = Command::new("hdiutil").args(["detach", dev]).status();
-            }
             let _ = fs::remove_dir_all(dir).await;
         }
         self.ram_device = None;


### PR DESCRIPTION
## Summary
- replace RAM disk logic with directory under `/tmp`
- adjust cleanup to remove this directory
- drop `diskutil`/`hdiutil` calls

## Testing
- `cargo check` *(fails: `gio-2.0.pc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8c0a56ac832ca936308182d5814f