### PR TITLE
Add bitrate and wrap count settings

### DIFF
--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -54,6 +54,8 @@ pub struct FfmpegProcess {
     pub video_source: String,
     pub audio_source: String,
     pub fps: u32,
+    pub wrap_count: u32,
+    pub bitrate: String,
 }
 
 impl FfmpegProcess {
@@ -67,6 +69,8 @@ impl FfmpegProcess {
             video_source: "1".into(),
             audio_source: "none".into(),
             fps: 30,
+            wrap_count: 11,
+            bitrate: "20M".into(),
         }
     }
 
@@ -90,6 +94,14 @@ impl FfmpegProcess {
         self.fps = fps;
     }
 
+    pub fn set_wrap_count(&mut self, wrap: u32) {
+        self.wrap_count = wrap;
+    }
+
+    pub fn set_bitrate(&mut self, bitrate: String) {
+        self.bitrate = bitrate;
+    }
+
     pub async fn start(&mut self) -> Result<(), String> {
         if let Some(child) = self.child.as_mut() {
             if child.try_wait().map_err(|e| e.to_string())?.is_none() {
@@ -99,9 +111,7 @@ impl FfmpegProcess {
         if self.child.is_some() {
             self.stop().await?;
         }
-        const WRAP: u32 = 11;
         const RAM_MB: u32 = 512;
-        const BITRATE: &str = "20M";
 
         let blocks = RAM_MB * 2048;
         let output = Command::new("hdiutil")
@@ -139,7 +149,7 @@ impl FfmpegProcess {
                 "-bf",
                 "0",
                 "-b:v",
-                BITRATE,
+                &self.bitrate,
                 "-g",
                 &gop.to_string(),
                 "-keyint_min",
@@ -156,11 +166,11 @@ impl FfmpegProcess {
                 "-segment_format",
                 "ts",
                 "-segment_wrap",
-                &WRAP.to_string(),
+                &self.wrap_count.to_string(),
                 "-segment_list",
                 &dir.join("list.m3u8").to_string_lossy(),
                 "-segment_list_size",
-                &WRAP.to_string(),
+                &self.wrap_count.to_string(),
                 "-segment_list_type",
                 "m3u8",
                 "-segment_list_flags",
@@ -195,7 +205,6 @@ impl FfmpegProcess {
     }
 
     pub async fn save(&mut self) -> Result<PathBuf, String> {
-        const WRAP: u32 = 11;
 
         let dir = if let Some(d) = &self.ram_dir {
             d.clone()
@@ -203,8 +212,8 @@ impl FfmpegProcess {
             return Err("ffmpeg not running".into());
         };
 
-        let offset = -(WRAP as i32 - 1);
-        let dur = self.segment_seconds * (WRAP - 1);
+        let offset = -(self.wrap_count as i32 - 1);
+        let dur = self.segment_seconds * (self.wrap_count - 1);
         let ts = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
         let mut out = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
         out.push("Movies");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -282,6 +282,8 @@ async fn save_settings_cmd(
         proc.set_video_source(settings.video_source.clone());
         proc.set_audio_source(settings.audio_source.clone());
         proc.set_fps(settings.fps);
+        proc.set_wrap_count(settings.wrap_count);
+        proc.set_bitrate(settings.bitrate.clone());
     }
     save_settings(&path.0, &settings).map_err(|e| e.to_string())
 }
@@ -294,6 +296,8 @@ async fn start_ffmpeg_replay(
     video_source: Option<String>,
     audio_source: Option<String>,
     fps: Option<u32>,
+    wrap_count: Option<u32>,
+    bitrate: Option<String>,
 ) -> Result<(), String> {
     let mut proc = state.0.lock().await;
     {
@@ -311,6 +315,12 @@ async fn start_ffmpeg_replay(
     }
     if let Some(f) = fps {
         proc.set_fps(f);
+    }
+    if let Some(w) = wrap_count {
+        proc.set_wrap_count(w);
+    }
+    if let Some(b) = bitrate {
+        proc.set_bitrate(b);
     }
     proc.start().await
 }
@@ -437,6 +447,8 @@ pub fn run() {
             ffmpeg_proc.set_video_source(settings.video_source.clone());
             ffmpeg_proc.set_audio_source(settings.audio_source.clone());
             ffmpeg_proc.set_fps(settings.fps);
+            ffmpeg_proc.set_wrap_count(settings.wrap_count);
+            ffmpeg_proc.set_bitrate(settings.bitrate.clone());
 
             let status = AppStatus {
                 game_state: GameState::NotStarted,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -11,6 +11,8 @@ pub struct AppSettings {
     pub fps: u32,
     pub video_source: String,
     pub audio_source: String,
+    pub wrap_count: u32,
+    pub bitrate: String,
 }
 
 impl Default for AppSettings {
@@ -21,6 +23,8 @@ impl Default for AppSettings {
             fps: 30,
             video_source: "1".into(),
             audio_source: "none".into(),
+            wrap_count: 11,
+            bitrate: "20M".into(),
         }
     }
 }

--- a/src/settings.html
+++ b/src/settings.html
@@ -58,6 +58,14 @@
             <label class="form-label" for="audioSourceInput">音声ソース</label>
             <select class="form-select" id="audioSourceInput"></select>
           </div>
+          <div class="col-auto">
+            <label class="form-label" for="wrapCountInput">ラップ数</label>
+            <input class="form-control" id="wrapCountInput" type="number" min="1" value="11" />
+          </div>
+          <div class="col-auto">
+            <label class="form-label" for="bitrateInput">ビットレート</label>
+            <input class="form-control" id="bitrateInput" type="text" value="20M" />
+          </div>
         </div>
         <button class="btn btn-success me-2" id="btnReplayStart">開始</button>
         <button class="btn btn-warning me-2" id="btnReplayStop">停止</button>

--- a/src/settings.js
+++ b/src/settings.js
@@ -34,8 +34,10 @@ window.addEventListener("DOMContentLoaded", async () => {
     const fps = parseInt(document.getElementById('fpsInput').value, 10);
     const videoSource = document.getElementById('videoSourceInput').value;
     const audioSource = document.getElementById('audioSourceInput').value;
+    const wrapCount = parseInt(document.getElementById('wrapCountInput').value, 10);
+    const bitrate = document.getElementById('bitrateInput').value;
     try {
-      await invoke('start_ffmpeg_replay', { segmentSeconds, fps, videoSource, audioSource });
+      await invoke('start_ffmpeg_replay', { segmentSeconds, fps, videoSource, audioSource, wrapCount, bitrate });
       logEvent("🔁 リプレイバッファを開始しました");
     } catch (e) {
       logEvent(`⚠️ リプレイバッファの開始に失敗しました: ${e}`);
@@ -100,6 +102,8 @@ async function loadSettings() {
   document.getElementById('fpsInput').value = s.fps;
   document.getElementById('videoSourceInput').value = s.video_source;
   document.getElementById('audioSourceInput').value = s.audio_source;
+  document.getElementById('wrapCountInput').value = s.wrap_count;
+  document.getElementById('bitrateInput').value = s.bitrate;
   document.getElementById('modeToggle').checked = s.recording_mode === 'Shell';
 }
 
@@ -133,6 +137,8 @@ async function saveSettings() {
     fps: parseInt(document.getElementById('fpsInput').value, 10),
     video_source: document.getElementById('videoSourceInput').value,
     audio_source: document.getElementById('audioSourceInput').value,
+    wrap_count: parseInt(document.getElementById('wrapCountInput').value, 10),
+    bitrate: document.getElementById('bitrateInput').value,
     recording_mode: document.getElementById('modeToggle').checked ? 'Shell' : 'Obs'
   };
   await invoke('save_settings_cmd', { settings });


### PR DESCRIPTION
## Summary
- store `wrap_count` and `bitrate` in `AppSettings`
- expose new inputs on the settings page
- send wrap count and bitrate with `start_ffmpeg_replay`
- use these values inside `FfmpegProcess`

## Testing
- `cargo check` *(fails: libsoup-3.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d8c0c79c4832c80aee983d12d48d5