### PR TITLE
Add trigger file monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ When starting the replay buffer from the Tauri application, you can override sev
 
 These values are passed directly to `ffmpeg_replaybuffer.sh` when it is spawned.
 
+While the replay buffer is running, creating a `.trigger_save` file inside the
+segment directory will cause the buffer to be saved. Creating a `.trigger_quit`
+file will stop the replay buffer entirely. Both files are removed automatically
+after they are processed.
+
 ### ffmpeg download location
 
 The application stores its own ffmpeg binary under the directory returned by

--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -90,7 +90,7 @@ impl FfmpegProcess {
         self.fps = fps;
     }
 
-    pub async fn start(&mut self) -> Result<(), String> {
+    pub async fn start(&mut self, shared: SharedFfmpegProcess) -> Result<(), String> {
         if let Some(child) = self.child.as_mut() {
             if child.try_wait().map_err(|e| e.to_string())?.is_none() {
                 return Ok(());
@@ -171,8 +171,29 @@ impl FfmpegProcess {
             .map_err(|e| e.to_string())?;
 
         self.child = Some(child);
-        self.ram_device = Some(dev);
-        self.ram_dir = Some(dir);
+        self.ram_device = Some(dev.clone());
+        self.ram_dir = Some(dir.clone());
+
+        let save_path = dir.join(".trigger_save");
+        let quit_path = dir.join(".trigger_quit");
+        tauri::async_runtime::spawn(async move {
+            use tokio::time::{sleep, Duration};
+            loop {
+                if fs::metadata(&save_path).await.is_ok() {
+                    let _ = fs::remove_file(&save_path).await;
+                    let mut p = shared.lock().await;
+                    let _ = p.save().await;
+                }
+                if fs::metadata(&quit_path).await.is_ok() {
+                    let _ = fs::remove_file(&quit_path).await;
+                    let mut p = shared.lock().await;
+                    let _ = p.stop().await;
+                    break;
+                }
+                sleep(Duration::from_millis(250)).await;
+            }
+        });
+
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -88,8 +88,9 @@ async fn start_recording(
             Ok(())
         }
         RecordingMode::Shell => {
-            let mut proc = ffmpeg_state.0.lock().await;
-            proc.start().await
+            let shared = ffmpeg_state.0.clone();
+            let mut proc = shared.lock().await;
+            proc.start(shared).await
         }
     }
 }
@@ -138,8 +139,9 @@ async fn start_replay_buffer(
             Ok(())
         }
         RecordingMode::Shell => {
-            let mut proc = ffmpeg_state.0.lock().await;
-            proc.start().await
+            let shared = ffmpeg_state.0.clone();
+            let mut proc = shared.lock().await;
+            proc.start(shared).await
         }
     }
 }
@@ -312,7 +314,8 @@ async fn start_ffmpeg_replay(
     if let Some(f) = fps {
         proc.set_fps(f);
     }
-    proc.start().await
+    let shared = state.0.clone();
+    proc.start(shared).await
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- add background task in `FfmpegProcess::start` that looks for `.trigger_save` and `.trigger_quit`
- update command callers for new start signature
- document trigger files in README
- shorten poll interval

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: system library `gio-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8c0b7c24832ca98d2295fdccada5