### PR TITLE
Add configurable save directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The commands above require that the Rust toolchain is installed since Tauri comp
 
 1. Install the OBS WebSocket plugin and restart OBS.
 2. Open *Tools → WebSocket Server Settings* and enable the server (default port `4455`).
-3. Configure your recording or replay buffer path in OBS.
+3. Configure your recording or replay buffer path in OBS or set it from the application's settings.
 4. Use the same port and password (if set) in this application's settings so it can control OBS.
 
 ## League of Legends Setup
@@ -49,7 +49,7 @@ Start the LoL client before launching the app. The client exposes an API that th
 5. Each clip is accompanied by a `replay_<timestamp>.json` file listing all LoL events
    from the clip duration along with their offsets from the start of the video.
 6. Optionally choose to encode clips with ffmpeg for easier sharing.
-7. Use the **設定保存** button to persist your current options. They are loaded automatically on startup.
+7. Use the **設定保存** button to persist your current options. They are loaded automatically on startup. You can also set the folder where recordings and clips are saved from the settings screen. The same path is used for OBS recordings and ffmpeg clips.
 
 ## `ffmpeg_replaybuffer.sh` (macOS)
 
@@ -73,9 +73,10 @@ Parameters:
 - `-t SEG_S` – length of each segment in seconds (default `6`).
 - `-n WRAP` – number of segments kept in the buffer (default `11`).
 - `-r RAM_MB` – size of the RAM disk in megabytes (default `512`).
+- `-o OUT_DIR` – directory where saved clips are written (default `~/Movies`).
 
 While the script is running it displays `REC ▶︎`. Press **s** at any time to
-save the most recent replay buffer to `$HOME/Movies` as
+save the most recent replay buffer to the specified output directory (default `~/Movies`) as
 `replay_<timestamp>.mp4`. Press **Esc** or **q** to quit.
 
 Once integrated with the Tauri app, the application will spawn this script

--- a/ffmpeg_replaybuffer.sh
+++ b/ffmpeg_replaybuffer.sh
@@ -2,14 +2,15 @@
 set -Eeuo pipefail
 
 FFMPEG_BIN=${FFMPEG_BIN:-ffmpeg}
-FPS=30 BITRATE=20M SRC="1:none" SEG_S=6 WRAP=11 RAM_MB=512
+FPS=30 BITRATE=20M SRC="1:none" SEG_S=6 WRAP=11 RAM_MB=512 OUT_DIR="$HOME/Movies"
 
-while getopts "f:b:s:t:n:r:h" o; do
+while getopts "f:b:s:t:n:r:o:h" o; do
   case $o in
     f) FPS=$OPTARG ;; b) BITRATE=$OPTARG ;;
     s) SRC=$OPTARG ;; t) SEG_S=$OPTARG ;;
     n) WRAP=$OPTARG ;; r) RAM_MB=$OPTARG ;;
-    h|*) echo "usage: $0 [-f fps] [-b bitrate] [-s src] [-t seg_sec] [-n wrap] [-r ram_mb]"; exit 0;;
+    o) OUT_DIR=$OPTARG ;;
+    h|*) echo "usage: $0 [-f fps] [-b bitrate] [-s src] [-t seg_sec] [-n wrap] [-r ram_mb] [-o out_dir]"; exit 0;;
   esac
 done
 
@@ -65,7 +66,7 @@ while true; do
     s)
       ts=$(date +%Y%m%d_%H%M%S)
       "$FFMPEG_BIN" -nostdin -y -live_start_index "$OFFSET" -i "$DIR/list.m3u8" \
-             -t "$DUR" -c copy -movflags +faststart "$HOME/Movies/replay_$ts.mp4"
+             -t "$DUR" -c copy -movflags +faststart "$OUT_DIR/replay_$ts.mp4" 
       echo "📼 saved $ts"
       ;;
     $'\x1b'|q) break ;;

--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -10,6 +10,12 @@ use crate::lol::LolEvent;
 use serde::Serialize;
 use tokio::fs;
 
+fn default_save_dir_path() -> PathBuf {
+    let mut dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    dir.push("Movies");
+    dir
+}
+
 /// Download or locate ffmpeg binary
 pub async fn ensure_ffmpeg_path(app: &App) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let mut dir = app.path().app_local_data_dir().unwrap();
@@ -56,6 +62,7 @@ pub struct FfmpegProcess {
     pub fps: u32,
     pub wrap_count: u32,
     pub bitrate: String,
+    pub save_dir: PathBuf,
 }
 
 impl FfmpegProcess {
@@ -71,6 +78,7 @@ impl FfmpegProcess {
             fps: 30,
             wrap_count: 11,
             bitrate: "20M".into(),
+            save_dir: default_save_dir_path(),
         }
     }
 
@@ -100,6 +108,10 @@ impl FfmpegProcess {
 
     pub fn set_bitrate(&mut self, bitrate: String) {
         self.bitrate = bitrate;
+    }
+
+    pub fn set_save_dir(&mut self, dir: PathBuf) {
+        self.save_dir = dir;
     }
 
     pub async fn start(&mut self, shared: SharedFfmpegProcess) -> Result<(), String> {
@@ -222,8 +234,7 @@ impl FfmpegProcess {
         let offset = -(self.wrap_count as i32 - 1);
         let dur = self.segment_seconds * (self.wrap_count - 1);
         let ts = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
-        let mut out = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-        out.push("Movies");
+        let mut out = self.save_dir.clone();
         fs::create_dir_all(&out).await.map_err(|e| e.to_string())?;
         out.push(format!("replay_{}.mp4", ts));
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,7 +17,7 @@ mod ffmpeg;
 
 use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState};
 use lol::{AllGameData, LolEvent};
-use obs::{send_obs_command_wrapper, send_obs_request_wrapper, ObsWsState, SharedObsWsClient};
+use obs::{send_obs_command_wrapper, send_obs_request_wrapper, set_record_directory, ObsWsState, SharedObsWsClient};
 use ffmpeg::{FfmpegProcess, FfmpegState, SharedFfmpegProcess, ensure_ffmpeg_path, write_clip_metadata};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -191,16 +191,28 @@ async fn save_replay_buffer(
 }
 
 #[tauri::command]
-async fn get_saved_directory(_state: tauri::State<'_, AppStatusState>, obs_state: tauri::State<'_, ObsWsState>) -> Result<String, String> {
-    let resp = send_obs_request_wrapper(obs_state.0.clone(), "GetRecordDirectory").await?;
-    let dir = resp
-        .get("d")
-        .and_then(|d| d.get("responseData"))
-        .and_then(|rd| rd.get("recordDirectory"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    Ok(dir)
+async fn get_saved_directory(state: tauri::State<'_, SettingsState>) -> Result<String, String> {
+    Ok(state.0.lock().unwrap().save_dir.clone())
+}
+
+#[tauri::command]
+async fn set_saved_directory(
+    dir: String,
+    settings: tauri::State<'_, SettingsState>,
+    path: tauri::State<'_, SettingsPath>,
+    obs_state: tauri::State<'_, ObsWsState>,
+    ffmpeg_state: tauri::State<'_, FfmpegState>,
+) -> Result<(), String> {
+    {
+        let mut set = settings.0.lock().unwrap();
+        set.save_dir = dir.clone();
+        save_settings(&path.0, &set).map_err(|e| e.to_string())?;
+    }
+    {
+        let mut proc = ffmpeg_state.0.lock().await;
+        proc.set_save_dir(PathBuf::from(&dir));
+    }
+    obs::set_record_directory(obs_state.0.clone(), &dir).await
 }
 
 #[derive(Serialize)]
@@ -212,15 +224,9 @@ struct SavedVideoInfo {
 }
 
 #[tauri::command]
-async fn list_saved_videos(obs_state: tauri::State<'_, ObsWsState>) -> Result<Vec<SavedVideoInfo>, String> {
-    let resp = send_obs_request_wrapper(obs_state.0.clone(), "GetRecordDirectory").await?;
-    let dir = resp
-        .get("d")
-        .and_then(|d| d.get("responseData"))
-        .and_then(|rd| rd.get("recordDirectory"))
-        .and_then(|v| v.as_str())
-        .ok_or("no dir")?;
-    let mut entries = fs::read_dir(dir).await.map_err(|e| e.to_string())?;
+async fn list_saved_videos(settings: tauri::State<'_, SettingsState>) -> Result<Vec<SavedVideoInfo>, String> {
+    let dir = settings.0.lock().unwrap().save_dir.clone();
+    let mut entries = fs::read_dir(&dir).await.map_err(|e| e.to_string())?;
     let mut files = Vec::new();
     while let Some(ent) = entries.next_entry().await.map_err(|e| e.to_string())? {
         let path = ent.path();
@@ -287,6 +293,7 @@ async fn save_settings_cmd(
         proc.set_fps(settings.fps);
         proc.set_wrap_count(settings.wrap_count);
         proc.set_bitrate(settings.bitrate.clone());
+        proc.set_save_dir(PathBuf::from(settings.save_dir.clone()));
     }
     save_settings(&path.0, &settings).map_err(|e| e.to_string())
 }
@@ -528,6 +535,7 @@ pub fn run() {
             stop_replay_buffer,
             save_replay_buffer,
             get_saved_directory,
+            set_saved_directory,
             start_ffmpeg_replay,
             stop_ffmpeg_replay,
             save_ffmpeg_clip,
@@ -549,6 +557,7 @@ pub fn run() {
             ffmpeg_proc.set_fps(settings.fps);
             ffmpeg_proc.set_wrap_count(settings.wrap_count);
             ffmpeg_proc.set_bitrate(settings.bitrate.clone());
+            ffmpeg_proc.set_save_dir(PathBuf::from(settings.save_dir.clone()));
 
             let status = AppStatus {
                 game_state: GameState::NotStarted,
@@ -570,6 +579,12 @@ pub fn run() {
             _app.manage(FfmpegState(ffmpeg_process.clone()));
             _app.manage(settings_state);
             _app.manage(settings_path_state);
+
+            let dir = settings.save_dir.clone();
+            let obs_ws_client_clone2 = obs_ws_client.clone();
+            tauri::async_runtime::spawn(async move {
+                let _ = set_record_directory(obs_ws_client_clone2, &dir).await;
+            });
 
             let obs_ws_client_clone = obs_ws_client.clone();
             let ffmpeg_process_clone = ffmpeg_process.clone();

--- a/src-tauri/src/obs.rs
+++ b/src-tauri/src/obs.rs
@@ -140,3 +140,48 @@ pub async fn send_obs_request_wrapper(shared: SharedObsWsClient, command: &str) 
     result
 }
 
+pub async fn set_record_directory(shared: SharedObsWsClient, dir: &str) -> Result<(), String> {
+    let mut needs_connect = false;
+    {
+        let client_guard = shared.lock().unwrap();
+        needs_connect = client_guard.is_none();
+    }
+    if needs_connect {
+        let client = ObsWsClient::connect_and_identify("ws://127.0.0.1:4455")
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut client_guard = shared.lock().unwrap();
+        *client_guard = Some(client);
+    }
+
+    let mut client_opt = {
+        let mut guard = shared.lock().unwrap();
+        guard.take()
+    };
+    use serde_json::json;
+    use tokio_tungstenite::tungstenite::Message;
+    let result = if let Some(ref mut client) = client_opt {
+        let req = json!({
+            "op": 6,
+            "d": {
+                "requestType": "SetRecordDirectory",
+                "requestId": "tauri-lol-obs-002",
+                "requestData": { "recordDirectory": dir }
+            }
+        });
+        client
+            .ws
+            .send(Message::Text(req.to_string()))
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    } else {
+        Err("OBS WS Client not connected".into())
+    };
+    {
+        let mut guard = shared.lock().unwrap();
+        *guard = client_opt;
+    }
+    result
+}
+

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -13,6 +13,8 @@ pub struct AppSettings {
     pub audio_source: String,
     pub wrap_count: u32,
     pub bitrate: String,
+    #[serde(default = "default_save_dir")]
+    pub save_dir: String,
 }
 
 impl Default for AppSettings {
@@ -25,8 +27,16 @@ impl Default for AppSettings {
             audio_source: "none".into(),
             wrap_count: 11,
             bitrate: "20M".into(),
+            save_dir: default_save_dir(),
         }
     }
+}
+
+fn default_save_dir() -> String {
+    use std::path::PathBuf;
+    let mut dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    dir.push("Movies");
+    dir.to_string_lossy().to_string()
 }
 
 pub fn load_settings(path: &Path) -> Option<AppSettings> {

--- a/src/settings.html
+++ b/src/settings.html
@@ -74,6 +74,10 @@
 
       <div class="button-group mb-4">
         <h2 class="h5 mb-3">🛠 ユーティリティ</h2>
+        <div class="input-group mb-2">
+          <input class="form-control" id="saveDirInput" type="text" />
+          <button class="btn btn-outline-secondary" id="chooseDirBtn">選択</button>
+        </div>
         <button class="btn btn-outline-primary" id="btnGetDir">保存先を開く</button>
         <button class="btn btn-outline-success ms-2" id="btnSaveSettings">設定保存</button>
       </div>

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,4 +1,5 @@
 const { invoke } = window.__TAURI__.core;
+const { open } = window.__TAURI__.dialog;
 
 window.addEventListener("DOMContentLoaded", async () => {
   await loadDevices();
@@ -85,9 +86,17 @@ window.addEventListener("DOMContentLoaded", async () => {
     updateStatus();
   });
 
+  document.getElementById('chooseDirBtn').addEventListener('click', async () => {
+    const selected = await open({ directory: true });
+    if (selected) {
+      document.getElementById('saveDirInput').value = selected;
+      await invoke('set_saved_directory', { dir: selected });
+    }
+  });
+
   document.getElementById('btnGetDir').addEventListener('click', async () => {
     const dir = await invoke('get_saved_directory');
-    logEvent(`📁 保存ディレクトリ: ${dir}`);
+    await open(dir);
   });
 
   document.getElementById('btnSaveSettings').addEventListener('click', async () => {
@@ -125,6 +134,7 @@ async function loadSettings() {
   document.getElementById('wrapCountInput').value = s.wrap_count;
   document.getElementById('bitrateInput').value = s.bitrate;
   document.getElementById('modeToggle').checked = s.recording_mode === 'Shell';
+  document.getElementById('saveDirInput').value = s.save_dir;
 }
 
 async function loadDevices() {
@@ -159,8 +169,10 @@ async function saveSettings() {
     audio_source: document.getElementById('audioSourceInput').value,
     wrap_count: parseInt(document.getElementById('wrapCountInput').value, 10),
     bitrate: document.getElementById('bitrateInput').value,
-    recording_mode: document.getElementById('modeToggle').checked ? 'Shell' : 'Obs'
+    recording_mode: document.getElementById('modeToggle').checked ? 'Shell' : 'Obs',
+    save_dir: document.getElementById('saveDirInput').value
   };
   await invoke('save_settings_cmd', { settings });
+  await invoke('set_saved_directory', { dir: settings.save_dir });
   logEvent('⚙️ 設定を保存しました');
 }


### PR DESCRIPTION
## Summary
- let users configure save directory for both OBS and ffmpeg
- persist save directory in settings
- expose `set_saved_directory` command
- allow choosing directory in settings UI
- update helper script with `-o` option

## Testing
- `cargo check` *(fails: glib-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68501cfe1110832c8133aff7e6f9fc37