### PR TITLE
Fix mode-specific screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,14 @@ The application stores its own ffmpeg binary under the directory returned by
 `~/Library/Application Support/<app>/ffmpeg/ffmpeg`. Replace the binary there to
 update or override the version shipped by default.
 
+## Screen and Function Mapping
+
+The frontend now has **five** HTML pages: Home, OBS Mode, FFmpeg Mode, Saved Videos, and Video Detail. Each page links to the others via the shared navigation bar.
+
+| Screen | File | Transitions | Invoked Commands |
+|-------|------|-------------|------------------|
+| **Home** | `index.html` | Links to **OBS Mode**, **FFmpeg Mode**, **Videos** | – |
+| **OBS Mode** | `obs.html` | Navbar links to all screens | `get_status`, `start_recording`, `stop_recording`, `start_replay_buffer`, `stop_replay_buffer`, `save_replay_buffer`, `load_settings_cmd`, `save_settings_cmd`, `set_saved_directory`, `get_saved_directory` |
+| **FFmpeg Mode** | `ffmpeg.html` | Navbar links to all screens | `get_status`, `start_recording`, `stop_recording`, `start_ffmpeg_replay`, `stop_ffmpeg_replay`, `save_ffmpeg_clip`, `list_ffmpeg_devices`, `load_settings_cmd`, `save_settings_cmd`, `set_saved_directory`, `get_saved_directory` |
+| **Saved Videos** | `videos.html` | Navbar links to all screens. Entries open **Video Detail**. | `list_saved_videos` |
+| **Video Detail** | `video.html` | Navbar links to all screens | – (uses `convertFileSrc` for local playback) |

--- a/src/ffmpeg.html
+++ b/src/ffmpeg.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="vendor/bootstrap/bootstrap.min.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Settings - LoL Clip Tool</title>
+    <title>FFmpeg Mode - LoL Clip Tool</title>
     <script type="module" src="/settings.js" defer></script>
     <script defer src="vendor/bootstrap/bootstrap.bundle.min.js"></script>
   </head>
@@ -15,8 +15,9 @@
       <div class="container-fluid">
         <a class="navbar-brand" href="index.html">Clip Tool</a>
         <div class="navbar-nav">
-          <a class="nav-link" href="index.html">Top</a>
-          <a class="nav-link" href="settings.html">Settings</a>
+          <a class="nav-link" href="index.html">Home</a>
+          <a class="nav-link" href="obs.html">OBS Mode</a>
+          <a class="nav-link" href="ffmpeg.html">FFmpeg Mode</a>
           <a class="nav-link" href="videos.html">Videos</a>
         </div>
       </div>
@@ -27,7 +28,7 @@
       <div class="status-panel mb-3">
         <div><strong>ゲーム状態:</strong> <span id="gameState"></span></div>
         <div><strong>OBS状態:</strong> <span id="obsState"></span></div>
-        <div class="form-check form-switch mode-toggle">
+        <div class="form-check form-switch mode-toggle" style="display:none;">
           <input class="form-check-input" type="checkbox" id="modeToggle" />
           <label class="form-check-label" for="modeToggle">シェル録画を使用</label>
         </div>
@@ -88,5 +89,6 @@
       </div>
     </main>
 
+    <script>window.addEventListener("DOMContentLoaded",()=>{const t=document.getElementById("modeToggle");if(t){t.checked=true;t.disabled=true;}});</script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -14,19 +14,17 @@
       <div class="container-fluid">
         <a class="navbar-brand" href="index.html">Clip Tool</a>
         <div class="navbar-nav">
-          <a class="nav-link" href="index.html">Top</a>
-          <a class="nav-link" href="settings.html">Settings</a>
+          <a class="nav-link" href="index.html">Home</a>
+          <a class="nav-link" href="obs.html">OBS Mode</a>
+          <a class="nav-link" href="ffmpeg.html">FFmpeg Mode</a>
           <a class="nav-link" href="videos.html">Videos</a>
         </div>
       </div>
     </nav>
     <main class="container py-4 app-container">
       <h1 class="mb-4 text-center">LoL OBS Clip Tool</h1>
-      <p class="text-center">Welcome! Use this tool to record your highlights.</p>
-      <div class="d-flex justify-content-center gap-3">
-        <a href="settings.html" class="btn btn-primary">Go to Settings</a>
-        <a href="videos.html" class="btn btn-secondary">View Saved Videos</a>
-      </div>
+      <p class="text-center">Select OBS or FFmpeg mode from the navigation bar. Saved videos appear under Videos.</p>
+      
     </main>
   </body>
 </html>

--- a/src/obs.html
+++ b/src/obs.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="vendor/bootstrap/bootstrap.min.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OBS Mode - LoL Clip Tool</title>
+    <script type="module" src="/settings.js" defer></script>
+    <script defer src="vendor/bootstrap/bootstrap.bundle.min.js"></script>
+  </head>
+
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">Clip Tool</a>
+        <div class="navbar-nav">
+          <a class="nav-link" href="index.html">Home</a>
+          <a class="nav-link" href="obs.html">OBS Mode</a>
+          <a class="nav-link" href="ffmpeg.html">FFmpeg Mode</a>
+          <a class="nav-link" href="videos.html">Videos</a>
+        </div>
+      </div>
+    </nav>
+    <main class="container py-4 app-container">
+      <h1 class="mb-4 text-center">LoL イベントトリガー録画アプリ</h1>
+
+      <div class="status-panel mb-3">
+        <div><strong>ゲーム状態:</strong> <span id="gameState"></span></div>
+        <div><strong>OBS状態:</strong> <span id="obsState"></span></div>
+        <div class="form-check form-switch mode-toggle" style="display:none;">
+          <input class="form-check-input" type="checkbox" id="modeToggle" />
+          <label class="form-check-label" for="modeToggle">シェル録画を使用</label>
+        </div>
+      </div>
+
+      <div class="button-group mb-4">
+        <h2 class="h5 mb-3">🎥 録画操作</h2>
+        <button class="btn btn-primary me-2" id="btnStart">録画開始</button>
+        <button class="btn btn-secondary" id="btnStop">録画停止</button>
+      </div>
+
+      <div class="button-group mb-4">
+        <h2 class="h5 mb-3">🔁 リプレイバッファ</h2>
+        <button class="btn btn-success me-2" id="btnReplayStart">開始</button>
+        <button class="btn btn-warning me-2" id="btnReplayStop">停止</button>
+        <button class="btn btn-info" id="btnReplaySave">保存</button>
+      </div>
+
+
+      <div class="button-group mb-4">
+        <h2 class="h5 mb-3">🛠 ユーティリティ</h2>
+        <div class="input-group mb-2">
+          <input class="form-control" id="saveDirInput" type="text" />
+          <button class="btn btn-outline-secondary" id="chooseDirBtn">選択</button>
+        </div>
+        <button class="btn btn-outline-primary" id="btnGetDir">保存先を開く</button>
+        <button class="btn btn-outline-success ms-2" id="btnSaveSettings">設定保存</button>
+      </div>
+
+      <div class="log-container">
+        <h2 class="h5 mb-3">📜 ゲームイベントログ</h2>
+        <ul id="eventLog" class="list-unstyled"></ul>
+      </div>
+    </main>
+
+    <script>window.addEventListener("DOMContentLoaded",()=>{const t=document.getElementById("modeToggle");if(t){t.checked=false;t.disabled=true;}});</script>
+  </body>
+</html>

--- a/src/settings.js
+++ b/src/settings.js
@@ -2,15 +2,17 @@ const { invoke } = window.__TAURI__.core;
 const { open } = window.__TAURI__.dialog;
 
 window.addEventListener("DOMContentLoaded", async () => {
-  await loadDevices();
+  if (document.getElementById('videoSourceInput')) {
+    await loadDevices();
+  }
   await loadSettings();
   // 各ボタンにイベントリスナーを設定
-  document.getElementById('modeToggle').addEventListener('change', async (e) => {
+  document.getElementById('modeToggle')?.addEventListener('change', async (e) => {
     const mode = e.target.checked ? 'Shell' : 'Obs';
     await invoke('set_recording_mode', { mode });
     updateStatus();
   });
-  document.getElementById('btnStart').addEventListener('click', async () => {
+  document.getElementById('btnStart')?.addEventListener('click', async () => {
     try {
       await invoke('start_recording');
       logEvent("🎥 録画を開始しました");
@@ -20,7 +22,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     updateStatus();
   });
 
-  document.getElementById('btnStop').addEventListener('click', async () => {
+  document.getElementById('btnStop')?.addEventListener('click', async () => {
     try {
       await invoke('stop_recording');
       logEvent("⏹ 録画を停止しました");
@@ -30,7 +32,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     updateStatus();
   });
 
-  document.getElementById('btnReplayStart').addEventListener('click', async () => {
+  document.getElementById('btnReplayStart')?.addEventListener('click', async () => {
     const isShell = document.getElementById('modeToggle').checked;
     if (isShell) {
       const segmentSeconds = parseInt(document.getElementById('segmentSeconds').value, 10);
@@ -56,7 +58,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     updateStatus();
   });
 
-  document.getElementById('btnReplayStop').addEventListener('click', async () => {
+  document.getElementById('btnReplayStop')?.addEventListener('click', async () => {
     const isShell = document.getElementById('modeToggle').checked;
     try {
       if (isShell) {
@@ -71,7 +73,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     updateStatus();
   });
 
-  document.getElementById('btnReplaySave').addEventListener('click', async () => {
+  document.getElementById('btnReplaySave')?.addEventListener('click', async () => {
     const isShell = document.getElementById('modeToggle').checked;
     try {
       if (isShell) {
@@ -86,7 +88,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     updateStatus();
   });
 
-  document.getElementById('chooseDirBtn').addEventListener('click', async () => {
+  document.getElementById('chooseDirBtn')?.addEventListener('click', async () => {
     const selected = await open({ directory: true });
     if (selected) {
       document.getElementById('saveDirInput').value = selected;
@@ -94,12 +96,12 @@ window.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
-  document.getElementById('btnGetDir').addEventListener('click', async () => {
+  document.getElementById('btnGetDir')?.addEventListener('click', async () => {
     const dir = await invoke('get_saved_directory');
     await open(dir);
   });
 
-  document.getElementById('btnSaveSettings').addEventListener('click', async () => {
+  document.getElementById('btnSaveSettings')?.addEventListener('click', async () => {
     await saveSettings();
   });
 
@@ -112,10 +114,14 @@ async function updateStatus() {
   document.getElementById('gameState').textContent = status.game_state;
   document.getElementById('obsState').textContent = status.obs_state;
   const toggle = document.getElementById('modeToggle');
-  toggle.checked = status.recording_mode === 'Shell';
-  toggle.disabled = status.is_recording;
+  if (toggle) {
+    toggle.checked = status.recording_mode === 'Shell';
+    toggle.disabled = status.is_recording;
+  }
   const saveBtn = document.getElementById('btnReplaySave');
-  saveBtn.disabled = !status.replay_buffer_running;
+  if (saveBtn) {
+    saveBtn.disabled = !status.replay_buffer_running;
+  }
 }
 
 function logEvent(message) {
@@ -127,21 +133,30 @@ function logEvent(message) {
 
 async function loadSettings() {
   const s = await invoke('load_settings_cmd');
-  document.getElementById('segmentSeconds').value = s.segment_seconds;
-  document.getElementById('fpsInput').value = s.fps;
-  document.getElementById('videoSourceInput').value = s.video_source;
-  document.getElementById('audioSourceInput').value = s.audio_source;
-  document.getElementById('wrapCountInput').value = s.wrap_count;
-  document.getElementById('bitrateInput').value = s.bitrate;
-  document.getElementById('modeToggle').checked = s.recording_mode === 'Shell';
-  document.getElementById('saveDirInput').value = s.save_dir;
+  const seg = document.getElementById('segmentSeconds');
+  if (seg) seg.value = s.segment_seconds;
+  const fps = document.getElementById('fpsInput');
+  if (fps) fps.value = s.fps;
+  const vsrc = document.getElementById('videoSourceInput');
+  if (vsrc) vsrc.value = s.video_source;
+  const asrc = document.getElementById('audioSourceInput');
+  if (asrc) asrc.value = s.audio_source;
+  const wrap = document.getElementById('wrapCountInput');
+  if (wrap) wrap.value = s.wrap_count;
+  const br = document.getElementById('bitrateInput');
+  if (br) br.value = s.bitrate;
+  const toggle = document.getElementById('modeToggle');
+  if (toggle) toggle.checked = s.recording_mode === 'Shell';
+  const dir = document.getElementById('saveDirInput');
+  if (dir) dir.value = s.save_dir;
 }
 
 async function loadDevices() {
+  const vSel = document.getElementById('videoSourceInput');
+  const aSel = document.getElementById('audioSourceInput');
+  if (!vSel || !aSel) return;
   try {
     const list = await invoke('list_ffmpeg_devices');
-    const vSel = document.getElementById('videoSourceInput');
-    const aSel = document.getElementById('audioSourceInput');
     vSel.innerHTML = '';
     list.video.forEach((d) => {
       const opt = document.createElement('option');
@@ -162,16 +177,24 @@ async function loadDevices() {
 }
 
 async function saveSettings() {
-  const settings = {
-    segment_seconds: parseInt(document.getElementById('segmentSeconds').value, 10),
-    fps: parseInt(document.getElementById('fpsInput').value, 10),
-    video_source: document.getElementById('videoSourceInput').value,
-    audio_source: document.getElementById('audioSourceInput').value,
-    wrap_count: parseInt(document.getElementById('wrapCountInput').value, 10),
-    bitrate: document.getElementById('bitrateInput').value,
-    recording_mode: document.getElementById('modeToggle').checked ? 'Shell' : 'Obs',
-    save_dir: document.getElementById('saveDirInput').value
-  };
+  const base = await invoke('load_settings_cmd');
+  const settings = { ...base };
+  const seg = document.getElementById('segmentSeconds');
+  if (seg) settings.segment_seconds = parseInt(seg.value, 10);
+  const fps = document.getElementById('fpsInput');
+  if (fps) settings.fps = parseInt(fps.value, 10);
+  const vsrc = document.getElementById('videoSourceInput');
+  if (vsrc) settings.video_source = vsrc.value;
+  const asrc = document.getElementById('audioSourceInput');
+  if (asrc) settings.audio_source = asrc.value;
+  const wrap = document.getElementById('wrapCountInput');
+  if (wrap) settings.wrap_count = parseInt(wrap.value, 10);
+  const br = document.getElementById('bitrateInput');
+  if (br) settings.bitrate = br.value;
+  const toggle = document.getElementById('modeToggle');
+  if (toggle) settings.recording_mode = toggle.checked ? 'Shell' : 'Obs';
+  const dir = document.getElementById('saveDirInput');
+  if (dir) settings.save_dir = dir.value;
   await invoke('save_settings_cmd', { settings });
   await invoke('set_saved_directory', { dir: settings.save_dir });
   logEvent('⚙️ 設定を保存しました');

--- a/src/video.html
+++ b/src/video.html
@@ -19,8 +19,9 @@
       <div class="container-fluid">
         <a class="navbar-brand" href="index.html">Clip Tool</a>
         <div class="navbar-nav">
-          <a class="nav-link" href="index.html">Top</a>
-          <a class="nav-link" href="settings.html">Settings</a>
+          <a class="nav-link" href="index.html">Home</a>
+          <a class="nav-link" href="obs.html">OBS Mode</a>
+          <a class="nav-link" href="ffmpeg.html">FFmpeg Mode</a>
           <a class="nav-link" href="videos.html">Videos</a>
         </div>
       </div>

--- a/src/videos.html
+++ b/src/videos.html
@@ -14,8 +14,9 @@
       <div class="container-fluid">
         <a class="navbar-brand" href="index.html">Clip Tool</a>
         <div class="navbar-nav">
-          <a class="nav-link" href="index.html">Top</a>
-          <a class="nav-link" href="settings.html">Settings</a>
+          <a class="nav-link" href="index.html">Home</a>
+          <a class="nav-link" href="obs.html">OBS Mode</a>
+          <a class="nav-link" href="ffmpeg.html">FFmpeg Mode</a>
           <a class="nav-link" href="videos.html">Videos</a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add replay buffer controls to `obs.html`
- update `settings.js` to check elements before using them so both mode pages work

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509d9fa17c832c946cbaece1bc5f5a