### PR TITLE
Store clip metadata in SQLite

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +52,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -940,6 +958,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,9 +1491,28 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2005,6 +2054,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,6 +2100,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
@@ -2972,7 +3033,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3216,6 +3277,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,4 +28,5 @@ futures-util = "0.3.31"
 reqwest = {version = "*", features = ["json", "rustls-tls"] }
 chrono = "0.4.41"
 dirs = "6.0.0"
+rusqlite = { version = "0.29", features = ["bundled"] }
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,0 +1,171 @@
+use rusqlite::{Connection, params};
+use std::path::{Path, PathBuf};
+use crate::lol::LolEvent;
+use serde::Serialize;
+
+#[derive(Clone)]
+pub struct DbPath(pub PathBuf);
+
+pub async fn init_db(path: &Path) -> Result<(), String> {
+    let p = path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let conn = Connection::open(p).map_err(|e| e.to_string())?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS clips (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                path TEXT UNIQUE NOT NULL,
+                size INTEGER NOT NULL,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                clip_id INTEGER NOT NULL,
+                offset REAL NOT NULL,
+                event_json TEXT NOT NULL,
+                FOREIGN KEY(clip_id) REFERENCES clips(id) ON DELETE CASCADE
+            );",
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+pub async fn write_clip_metadata(
+    db_path: &Path,
+    video_path: &Path,
+    events: &[LolEvent],
+    clip_start: f64,
+) -> Result<(), String> {
+    let db = db_path.to_path_buf();
+    let file = video_path.to_path_buf();
+    let events_vec = events.to_vec();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let conn = Connection::open(db).map_err(|e| e.to_string())?;
+        let size = std::fs::metadata(&file).map_err(|e| e.to_string())?.len() as i64;
+        conn.execute(
+            "INSERT OR IGNORE INTO clips (path, size) VALUES (?1, ?2)",
+            params![file.to_string_lossy(), size],
+        )
+        .map_err(|e| e.to_string())?;
+        conn.execute(
+            "UPDATE clips SET size=?2 WHERE path=?1",
+            params![file.to_string_lossy(), size],
+        )
+        .map_err(|e| e.to_string())?;
+        let clip_id: i64 = conn
+            .query_row("SELECT id FROM clips WHERE path=?1", params![file.to_string_lossy()], |row| row.get(0))
+            .map_err(|e| e.to_string())?;
+        conn.execute("DELETE FROM events WHERE clip_id=?1", params![clip_id])
+            .map_err(|e| e.to_string())?;
+        let tx = conn.transaction().map_err(|e| e.to_string())?;
+        {
+            let mut stmt = tx
+                .prepare("INSERT INTO events (clip_id, offset, event_json) VALUES (?1, ?2, ?3)")
+                .map_err(|e| e.to_string())?;
+            for ev in events_vec {
+                let json = serde_json::to_string(&ev).map_err(|e| e.to_string())?;
+                let offset = ev.EventTime - clip_start;
+                stmt.execute(params![clip_id, offset, json])
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        tx.commit().map_err(|e| e.to_string())?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[derive(Serialize)]
+pub struct EventWithOffset {
+    #[serde(flatten)]
+    pub event: LolEvent,
+    pub offset: f64,
+}
+
+pub async fn get_clip_events(db_path: &Path, path: &Path) -> Result<Vec<EventWithOffset>, String> {
+    let db = db_path.to_path_buf();
+    let p = path.to_string_lossy().to_string();
+    tokio::task::spawn_blocking(move || -> Result<Vec<EventWithOffset>, String> {
+        let conn = Connection::open(db).map_err(|e| e.to_string())?;
+        let clip_id: i64 = conn
+            .query_row("SELECT id FROM clips WHERE path=?1", params![p], |row| row.get(0))
+            .map_err(|e| e.to_string())?;
+        let mut stmt = conn
+            .prepare("SELECT offset, event_json FROM events WHERE clip_id=?1 ORDER BY id")
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map(params![clip_id], |row| {
+                let offset: f64 = row.get(0)?;
+                let json: String = row.get(1)?;
+                Ok((offset, json))
+            })
+            .map_err(|e| e.to_string())?;
+        let mut out = Vec::new();
+        for r in rows {
+            let (offset, json) = r.map_err(|e| e.to_string())?;
+            let event: LolEvent = serde_json::from_str(&json).map_err(|e| e.to_string())?;
+            out.push(EventWithOffset { event, offset });
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+pub async fn list_clips(db_path: &Path) -> Result<Vec<(String, String, u64)>, String> {
+    let db = db_path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<Vec<(String, String, u64)>, String> {
+        let conn = Connection::open(db).map_err(|e| e.to_string())?;
+        let mut stmt = conn
+            .prepare("SELECT path, created_at, size FROM clips ORDER BY created_at DESC")
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map([], |row| {
+                let path: String = row.get(0)?;
+                let created: String = row.get(1)?;
+                let size: i64 = row.get(2)?;
+                Ok((path, created, size as u64))
+            })
+            .map_err(|e| e.to_string())?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(|e| e.to_string())?);
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+pub async fn cleanup_orphan_clips(db_path: &Path) -> Result<(), String> {
+    let db = db_path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let conn = Connection::open(db).map_err(|e| e.to_string())?;
+        let mut stmt = conn
+            .prepare("SELECT id, path FROM clips")
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map([], |row| {
+                let id: i64 = row.get(0)?;
+                let path: String = row.get(1)?;
+                Ok((id, path))
+            })
+            .map_err(|e| e.to_string())?;
+        for r in rows {
+            let (id, path) = r.map_err(|e| e.to_string())?;
+            if !std::path::Path::new(&path).exists() {
+                conn.execute("DELETE FROM clips WHERE id=?1", params![id])
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}

--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -7,7 +7,6 @@ use std::process::Child as CommandChild;
 use tauri::Manager;
 
 use crate::lol::LolEvent;
-use serde::Serialize;
 use tokio::fs;
 
 fn default_save_dir_path() -> PathBuf {
@@ -268,38 +267,11 @@ pub type SharedFfmpegProcess = Arc<AsyncMutex<FfmpegProcess>>;
 pub struct FfmpegState(pub SharedFfmpegProcess);
 
 pub async fn write_clip_metadata(
+    db_path: &std::path::Path,
     path: &std::path::Path,
     events: &[LolEvent],
     clip_start: f64,
 ) -> Result<(), String> {
-    #[derive(Serialize)]
-    struct EventWithOffset<'a> {
-        #[serde(flatten)]
-        event: &'a LolEvent,
-        offset: f64,
-    }
-
-    #[derive(Serialize)]
-    struct Metadata<'a> {
-        events: Vec<EventWithOffset<'a>>,
-    }
-
-    let events_with_offset = events
-        .iter()
-        .map(|e| EventWithOffset {
-            event: e,
-            offset: e.EventTime - clip_start,
-        })
-        .collect();
-
-    let data = Metadata {
-        events: events_with_offset,
-    };
-
-    let json_path = path.with_extension("json");
-    let contents = serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?;
-    fs::write(json_path, contents)
-        .await
-        .map_err(|e| e.to_string())
+    crate::db::write_clip_metadata(db_path, path, events, clip_start).await
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,11 +14,13 @@ mod settings;
 mod lol;
 mod obs;
 mod ffmpeg;
+mod db;
 
 use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState};
 use lol::{AllGameData, LolEvent};
 use obs::{send_obs_command_wrapper, send_obs_request_wrapper, set_record_directory, ObsWsState, SharedObsWsClient};
 use ffmpeg::{FfmpegProcess, FfmpegState, SharedFfmpegProcess, ensure_ffmpeg_path, write_clip_metadata};
+use db::{DbPath, init_db, get_clip_events, list_clips, cleanup_orphan_clips};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 enum GameState {
@@ -224,44 +226,28 @@ struct SavedVideoInfo {
 }
 
 #[tauri::command]
-async fn list_saved_videos(settings: tauri::State<'_, SettingsState>) -> Result<Vec<SavedVideoInfo>, String> {
-    let dir = settings.0.lock().unwrap().save_dir.clone();
-    let mut entries = fs::read_dir(&dir).await.map_err(|e| e.to_string())?;
+async fn list_saved_videos(db: tauri::State<'_, DbPath>) -> Result<Vec<SavedVideoInfo>, String> {
+    cleanup_orphan_clips(&db.0).await?;
+    let clips = list_clips(&db.0).await?;
     let mut files = Vec::new();
-    while let Some(ent) = entries.next_entry().await.map_err(|e| e.to_string())? {
-        let path = ent.path();
-        if path.is_file() {
-            if let Some(ext) = path.extension() {
-                if ext == "mp4" || ext == "mkv" || ext == "mov" {
-                    let name = path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    let (modified, size) = match ent.metadata().await {
-                        Ok(meta) => {
-                            let modified = meta
-                                .modified()
-                                .ok()
-                                .map(|t| {
-                                    let dt: chrono::DateTime<chrono::Local> = t.into();
-                                    dt.format("%Y-%m-%d %H:%M:%S").to_string()
-                                })
-                                .unwrap_or_default();
-                            (modified, meta.len())
-                        }
-                        Err(_) => (String::new(), 0),
-                    };
-                    files.push(SavedVideoInfo {
-                        path: path.to_string_lossy().to_string(),
-                        name,
-                        modified,
-                        size,
-                    });
-                }
-            }
-        }
+    for (path, created, size) in clips {
+        let name = std::path::Path::new(&path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        files.push(SavedVideoInfo {
+            path,
+            name,
+            modified: created,
+            size,
+        });
     }
     Ok(files)
+}
+
+#[tauri::command]
+async fn get_clip_metadata(path: String, db: tauri::State<'_, DbPath>) -> Result<Vec<db::EventWithOffset>, String> {
+    get_clip_events(&db.0, std::path::Path::new(&path)).await
 }
 
 #[tauri::command]
@@ -541,6 +527,7 @@ pub fn run() {
             save_ffmpeg_clip,
             list_ffmpeg_devices,
             list_saved_videos,
+            get_clip_metadata,
             load_settings_cmd,
             save_settings_cmd,
             greet])
@@ -548,6 +535,10 @@ pub fn run() {
 
             let config_path = _app.path().config_dir().unwrap().join("settings.json");
             let settings = load_settings(&config_path).unwrap_or_default();
+            let db_path = _app.path().app_local_data_dir().unwrap().join("clips.db");
+            tauri::async_runtime::block_on(init_db(&db_path))?;
+            tauri::async_runtime::block_on(cleanup_orphan_clips(&db_path))?;
+            let db_state = DbPath(db_path.clone());
             let mut ffmpeg_path = PathBuf::new();
             ffmpeg_path.push("ffmpeg");
             let mut ffmpeg_proc = FfmpegProcess::new(ffmpeg_path);
@@ -579,6 +570,7 @@ pub fn run() {
             _app.manage(FfmpegState(ffmpeg_process.clone()));
             _app.manage(settings_state);
             _app.manage(settings_path_state);
+            _app.manage(db_state.clone());
 
             let dir = settings.save_dir.clone();
             let obs_ws_client_clone2 = obs_ws_client.clone();
@@ -588,6 +580,7 @@ pub fn run() {
 
             let obs_ws_client_clone = obs_ws_client.clone();
             let ffmpeg_process_clone = ffmpeg_process.clone();
+            let db_path_clone = db_state.clone();
 
             tauri::async_runtime::spawn(async move {
                 poll_lol_events(move |all_data: &AllGameData, new_events: Vec<LolEvent>| {
@@ -633,7 +626,7 @@ pub fn run() {
                                                             .into_iter()
                                                             .filter(|ev| ev.EventTime >= clip_start)
                                                             .collect();
-                                                        if let Err(e) = write_clip_metadata(&path, &relevant_events, clip_start).await {
+                                                        if let Err(e) = write_clip_metadata(&db_path_clone.0, &path, &relevant_events, clip_start).await {
                                                             eprintln!("Failed to write metadata: {}", e);
                                                         }
                                                     }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,4 +1,4 @@
-const { convertFileSrc } = window.__TAURI__.core;
+const { convertFileSrc, invoke } = window.__TAURI__.core;
 function eventColor(name) {
   switch (name) {
     case "ChampionKill":
@@ -63,16 +63,13 @@ function init() {
   }
 
 
-  // Load metadata JSON if available
-  const metadataPath = file.replace(/\.[^/.]+$/, '.json');
   let events = [];
-  fetch(convertFileSrc(metadataPath))
-    .then((r) => (r.ok ? r.json() : null))
+  invoke('get_clip_metadata', { path: file })
     .then((data) => {
-      if (data && Array.isArray(data.events)) {
-        events = data.events;
+      if (Array.isArray(data)) {
+        events = data;
       }
-        addMarkers();
+      addMarkers();
     })
     .catch(() => {
       /* ignore errors */


### PR DESCRIPTION
## Summary
- add rusqlite dependency and database handler
- save clip metadata in SQLite
- keep DB clean by removing entries for deleted files

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850a8417548832c96b14b1a97586e02