### PR TITLE
Add sample debug configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,21 @@ Tauri アプリからリプレイバッファを開始する際に、`ffmpeg_rep
 | **Saved Videos** | `videos.html` | ナビバーから全画面へ。項目をクリックすると **Video Detail** を開きます | `list_saved_videos` |
 | **Video Detail** | `video.html` | ナビバーから全画面へ | – (`convertFileSrc` を使用してローカル再生) |
 
+
+## デバッグ実行
+
+VSCode や JetBrains RustRover でデバッグを行う場合、`run-configs` ディレクトリにサンプルの実行設定を用意しています。必要に応じて以下の手順でコピーしてください。
+
+### VSCode
+
+```
+cp run-configs/vscode-launch.json .vscode/launch.json
+```
+
+### RustRover
+
+```
+mkdir -p .idea/runConfigurations
+cp run-configs/rustrover/TauriDev.run.xml .idea/runConfigurations/
+```
+

--- a/run-configs/rustrover/TauriDev.run.xml
+++ b/run-configs/rustrover/TauriDev.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration name="Tauri Dev" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="tauri" />
+    <option name="additionalArguments" value="dev" />
+    <option name="workingDirectory" value="$PROJECT_DIR$" />
+    <envs>
+      <env name="RUST_LOG" value="debug" />
+    </envs>
+  </configuration>
+</component>

--- a/run-configs/vscode-launch.json
+++ b/run-configs/vscode-launch.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Tauri",
+      "type": "lldb",
+      "request": "launch",
+      "cargo": {
+        "args": ["tauri", "dev"],
+        "filter": {
+          "name": "lol-clip-tool",
+          "kind": "bin"
+        }
+      },
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "RUST_LOG": "debug"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add sample `launch.json` for VSCode
- add sample run configuration for RustRover
- document how to copy these configs for debugging

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `gio-2.0` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6852100d36d8832c8f80cf7918075812