### PR TITLE
Enable overscroll-none across pages

### DIFF
--- a/src/ffmpeg.html
+++ b/src/ffmpeg.html
@@ -9,8 +9,8 @@
     <script type="module" src="/settings.js" defer></script>
   </head>
 
-  <body>
-    <nav class="bg-gray-800 text-gray-100 py-2">
+  <body class="h-screen flex flex-col overscroll-none">
+    <nav class="bg-gray-800 text-gray-100 py-2 overscroll-none">
       <div class="container mx-auto flex items-center gap-4">
         <a class="font-bold text-white" href="index.html">Clip Tool</a>
         <a class="hover:text-blue-400" href="index.html">Home</a>
@@ -19,7 +19,7 @@
         <a class="hover:text-blue-400" href="videos.html">Videos</a>
       </div>
     </nav>
-    <main class="container py-4 app-container">
+    <main class="container py-4 app-container overscroll-none">
       <h1 class="mb-4 text-center">LoL イベントトリガー録画アプリ</h1>
 
       <div class="flex flex-col md:flex-row w-full h-full gap-6">

--- a/src/index.html
+++ b/src/index.html
@@ -8,8 +8,8 @@
     <title>LoL Clip Tool</title>
     <script type="module" src="/main.js" defer></script>
   </head>
-  <body>
-    <nav class="bg-gray-800 text-gray-100 py-2">
+  <body class="h-screen flex flex-col overscroll-none">
+    <nav class="bg-gray-800 text-gray-100 py-2 overscroll-none">
       <div class="container mx-auto flex items-center gap-4">
         <a class="font-bold text-white" href="index.html">Clip Tool</a>
         <a class="hover:text-blue-400" href="index.html">Home</a>
@@ -18,7 +18,7 @@
         <a class="hover:text-blue-400" href="videos.html">Videos</a>
       </div>
     </nav>
-    <main class="container py-4 app-container">
+    <main class="container py-4 app-container overscroll-none">
       <h1 class="mb-4 text-center">LoL OBS Clip Tool</h1>
       <p class="text-center">Select OBS or FFmpeg mode from the navigation bar. Saved videos appear under Videos.</p>
       

--- a/src/obs.html
+++ b/src/obs.html
@@ -9,8 +9,8 @@
     <script type="module" src="/settings.js" defer></script>
   </head>
 
-  <body>
-    <nav class="bg-gray-800 text-gray-100 py-2">
+  <body class="h-screen flex flex-col overscroll-none">
+    <nav class="bg-gray-800 text-gray-100 py-2 overscroll-none">
       <div class="container mx-auto flex items-center gap-4">
         <a class="font-bold text-white" href="index.html">Clip Tool</a>
         <a class="hover:text-blue-400" href="index.html">Home</a>
@@ -19,7 +19,7 @@
         <a class="hover:text-blue-400" href="videos.html">Videos</a>
       </div>
     </nav>
-    <main class="container py-4 app-container">
+    <main class="container py-4 app-container overscroll-none">
       <h1 class="mb-4 text-center">LoL イベントトリガー録画アプリ</h1>
 
       <div class="flex flex-col md:flex-row w-full h-full gap-6">

--- a/src/videos.html
+++ b/src/videos.html
@@ -8,8 +8,8 @@
     <title>Saved Videos - LoL Clip Tool</title>
     <script type="module" src="/videos.js" defer></script>
   </head>
-  <body>
-    <nav class="bg-gray-800 text-gray-100 py-2">
+  <body class="h-screen flex flex-col overscroll-none">
+    <nav class="bg-gray-800 text-gray-100 py-2 overscroll-none">
       <div class="container mx-auto flex items-center gap-4">
         <a class="font-bold text-white" href="index.html">Clip Tool</a>
         <a class="hover:text-blue-400" href="index.html">Home</a>
@@ -18,7 +18,7 @@
         <a class="hover:text-blue-400" href="videos.html">Videos</a>
       </div>
     </nav>
-    <main class="container py-4 app-container">
+    <main class="container py-4 app-container overscroll-none">
       <h1 class="mb-4 text-center">Saved Videos</h1>
       <table class="table-auto w-full border border-gray-300">
         <thead>


### PR DESCRIPTION
## Summary
- apply `overscroll-none` to `<body>`, `<nav>` and `<main>` in index, obs, ffmpeg and videos pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68527219d67c832c973e86543cbdabc1