### PR TITLE
Add recording mode debug display

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Tauri アプリからリプレイバッファを開始する際に、`ffmpeg_rep
 | **Saved Videos** | `videos.html` | ナビバーから全画面へ。項目をクリックすると **Video Detail** を開きます | `list_saved_videos` |
 | **Video Detail** | `video.html` | ナビバーから全画面へ | – (`convertFileSrc` を使用してローカル再生) |
 
+ナビバー右端には現在の録画モードや録画中かどうかといったデバッグ用ステータスが表示されます。OBS を利用している場合は `OBS`、シェル録画 (ffmpeg) を利用している場合は `ffmpeg` と表示されるので、動作確認に活用してください。
+
 
 ## デバッグ実行
 

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,23 @@
+const { invoke } = window.__TAURI__.core;
+
+async function refreshDebug() {
+  try {
+    const status = await invoke('get_status');
+    const el = document.getElementById('debugStatus');
+    if (!el) return;
+    const modeText = status.recording_mode === 'Shell' ? 'ffmpeg' : 'OBS';
+    const recText = status.is_recording
+      ? status.replay_buffer_running
+        ? 'Buffering'
+        : 'Recording'
+      : 'Idle';
+    el.textContent = `Mode: ${modeText} | ${recText}`;
+  } catch (e) {
+    console.error('Failed to update debug status', e);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  refreshDebug();
+  setInterval(refreshDebug, 1500);
+});

--- a/src/ffmpeg.html
+++ b/src/ffmpeg.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FFmpeg Mode - LoL Clip Tool</title>
     <script type="module" src="/settings.js" defer></script>
+    <script type="module" src="/debug.js" defer></script>
   </head>
 
     <body class="h-screen flex flex-col overscroll-none">
@@ -17,6 +18,7 @@
         <a class="hover:text-blue-400" href="obs.html">OBS Mode</a>
         <a class="hover:text-blue-400" href="ffmpeg.html">FFmpeg Mode</a>
         <a class="hover:text-blue-400" href="videos.html">Videos</a>
+        <span id="debugStatus" class="ml-auto text-sm text-gray-400"></span>
       </div>
     </nav>
     <main class="container py-4 app-container overscroll-none">

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LoL Clip Tool</title>
     <script type="module" src="/main.js" defer></script>
+    <script type="module" src="/debug.js" defer></script>
   </head>
     <body class="h-screen flex flex-col overscroll-none">
       <nav class="bg-gray-800 text-gray-100 py-2 fixed top-0 left-0 w-full z-10 overscroll-none">
@@ -15,8 +16,9 @@
           <a class="hover:text-blue-400" href="index.html">Home</a>
           <a class="hover:text-blue-400" href="obs.html">OBS Mode</a>
           <a class="hover:text-blue-400" href="ffmpeg.html">FFmpeg Mode</a>
-          <a class="hover:text-blue-400" href="videos.html">Videos</a>
-        </div>
+        <a class="hover:text-blue-400" href="videos.html">Videos</a>
+        <span id="debugStatus" class="ml-auto text-sm text-gray-400"></span>
+      </div>
       </nav>
       <main class="container py-4 app-container overscroll-none">
         <h1 class="mb-4 text-center">LoL OBS Clip Tool</h1>

--- a/src/obs.html
+++ b/src/obs.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OBS Mode - LoL Clip Tool</title>
     <script type="module" src="/settings.js" defer></script>
+    <script type="module" src="/debug.js" defer></script>
   </head>
 
     <body class="h-screen flex flex-col overscroll-none">
@@ -17,6 +18,7 @@
         <a class="hover:text-blue-400" href="obs.html">OBS Mode</a>
         <a class="hover:text-blue-400" href="ffmpeg.html">FFmpeg Mode</a>
         <a class="hover:text-blue-400" href="videos.html">Videos</a>
+        <span id="debugStatus" class="ml-auto text-sm text-gray-400"></span>
       </div>
     </nav>
     <main class="container py-4 app-container overscroll-none">

--- a/src/settings.js
+++ b/src/settings.js
@@ -139,6 +139,16 @@ async function updateStatus() {
   if (saveBtn) {
     saveBtn.disabled = !status.replay_buffer_running;
   }
+  const dbg = document.getElementById('debugStatus');
+  if (dbg) {
+    const modeText = status.recording_mode === 'Shell' ? 'ffmpeg' : 'OBS';
+    const recText = status.is_recording
+      ? status.replay_buffer_running
+        ? 'Buffering'
+        : 'Recording'
+      : 'Idle';
+    dbg.textContent = `Mode: ${modeText} | ${recText}`;
+  }
 }
 
 // 画面のログ欄へテキストを追加

--- a/src/video.html
+++ b/src/video.html
@@ -12,6 +12,7 @@
     />
     <script src="https://vjs.zencdn.net/8.3.0/video.min.js"></script>
     <script type="module" src="/viewer.js" defer></script>
+    <script type="module" src="/debug.js" defer></script>
   </head>
   <body class="h-screen flex flex-col overscroll-none">
     <nav class="bg-gray-800 text-gray-100 py-2 fixed top-0 left-0 w-full z-10 overscroll-none">
@@ -22,6 +23,7 @@
         <a class="hover:text-blue-400" href="ffmpeg.html">FFmpeg Mode</a>
         <a class="hover:text-blue-400" href="videos.html">Videos</a>
         <a class="hover:text-blue-400" href="videos.html">< Back</a>
+        <span id="debugStatus" class="ml-auto text-sm text-gray-400"></span>
       </div>
     </nav>
     <main class="flex-1 overflow-y-auto pt-[48px] container py-4 app-container overscroll-none">

--- a/src/videos.html
+++ b/src/videos.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Saved Videos - LoL Clip Tool</title>
     <script type="module" src="/videos.js" defer></script>
+    <script type="module" src="/debug.js" defer></script>
   </head>
     <body class="h-screen flex flex-col overscroll-none">
     <nav class="bg-gray-800 text-gray-100 py-2 fixed top-0 left-0 w-full z-10 overscroll-none">
@@ -16,6 +17,7 @@
         <a class="hover:text-blue-400" href="obs.html">OBS Mode</a>
         <a class="hover:text-blue-400" href="ffmpeg.html">FFmpeg Mode</a>
         <a class="hover:text-blue-400" href="videos.html">Videos</a>
+        <span id="debugStatus" class="ml-auto text-sm text-gray-400"></span>
       </div>
     </nav>
     <main class="container py-4 app-container overscroll-none flex-1">


### PR DESCRIPTION
## Summary
- show recording mode and status on every page nav
- update status updater to fill debug info
- document debug info in README

## Testing
- `pnpm install`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `glib-2.0` pkg-config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853563e2d84832cacbe217036cb5438