### PR TITLE
Add Japanese comments across code

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -2,15 +2,18 @@ use std::path::{Path, PathBuf};
 use serde::{Serialize, Deserialize};
 use crate::lol::LolEvent;
 use tokio::fs;
+// ファイル操作やパス操作に必要なクレートを読み込む
 
 #[derive(Clone)]
 /// Wrapper to keep compatibility with previous DB path usage
 pub struct DbPath(pub PathBuf);
+// パスを保持するだけのシンプルなラッパー
 
 /// Initialize storage directory. This previously created an SQLite DB but now
 /// just ensures the directory exists.
 pub async fn init_db(path: &Path) -> Result<(), String> {
     if let Some(parent) = path.parent() {
+        // 親ディレクトリが無ければ作成する
         fs::create_dir_all(parent).await.map_err(|e| e.to_string())?;
     }
     Ok(())
@@ -23,17 +26,21 @@ pub async fn write_clip_metadata(
     events: &[LolEvent],
     clip_start: f64,
 ) -> Result<(), String> {
+    // 出力ファイル名を json に変換
     let out_path = video_path.with_extension("json");
     let events_with_offset: Vec<EventWithOffset> = events
         .iter()
         .cloned()
         .map(|ev| EventWithOffset {
+            // 各イベントにオフセットを付与
             event: ev.clone(),
             offset: ev.EventTime - clip_start,
         })
         .collect();
+    // JSON 文字列へ変換
     let json = serde_json::to_string_pretty(&events_with_offset)
         .map_err(|e| e.to_string())?;
+    // ファイルへ書き出し
     fs::write(out_path, json).await.map_err(|e| e.to_string())
 }
 
@@ -43,23 +50,28 @@ pub struct EventWithOffset {
     pub event: LolEvent,
     pub offset: f64,
 }
+// クリップ内でのイベント発生位置を保持
 
 /// Read clip metadata from the JSON file written by `write_clip_metadata`.
 pub async fn get_clip_events(
     _db_path: &Path,
     path: &Path,
 ) -> Result<Vec<EventWithOffset>, String> {
+    // JSON ファイルを開き内容を文字列で取得
     let json_path = path.with_extension("json");
     let contents = fs::read_to_string(json_path).await.map_err(|e| e.to_string())?;
+    // JSON を構造体へ変換
     serde_json::from_str(&contents).map_err(|e| e.to_string())
 }
 
 /// Stubbed implementation kept for compatibility.
 pub async fn list_clips(_db_path: &Path) -> Result<Vec<(String, String, u64)>, String> {
+    // 現在は DB を利用していないため空配列を返す
     Ok(Vec::new())
 }
 
 /// No-op cleanup; previously removed orphan DB entries.
 pub async fn cleanup_orphan_clips(_db_path: &Path) -> Result<(), String> {
+    // 互換性のために残されたダミー実装
     Ok(())
 }

--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::process::{Command};
 use std::process::Child as CommandChild;
 use tauri::Manager;
+// ffmpeg 制御に必要な標準ライブラリと Tauri の型をインポート
 
 use crate::lol::LolEvent;
 use tokio::fs;
@@ -33,6 +34,7 @@ pub struct FfmpegProcess {
     pub bitrate: String,
     pub save_dir: PathBuf,
 }
+// ffmpeg 実行に必要な状態をまとめた構造体
 
 impl FfmpegProcess {
     pub fn new(ffmpeg_path: PathBuf) -> Self {
@@ -51,36 +53,45 @@ impl FfmpegProcess {
             save_dir: default_save_dir_path(),
         }
     }
+    // 各種 setter でパラメータを変更可能
 
     pub fn set_segment_seconds(&mut self, secs: u32) {
+        // 1 セグメントの長さを更新
         self.segment_seconds = secs;
     }
 
     pub fn set_video_source(&mut self, src: String) {
+        // キャプチャするビデオデバイス番号
         self.video_source = src;
     }
 
     pub fn set_ffmpeg_path(&mut self, path: PathBuf) {
+        // 利用する ffmpeg 実行ファイルを差し替え
         self.ffmpeg_path = path;
     }
 
     pub fn set_audio_source(&mut self, src: String) {
+        // キャプチャするオーディオデバイス番号
         self.audio_source = src;
     }
 
     pub fn set_fps(&mut self, fps: u32) {
+        // 出力フレームレートを設定
         self.fps = fps;
     }
 
     pub fn set_wrap_count(&mut self, wrap: u32) {
+        // 保持するセグメント数を設定
         self.wrap_count = wrap;
     }
 
     pub fn set_bitrate(&mut self, bitrate: String) {
+        // エンコード時のビットレート
         self.bitrate = bitrate;
     }
 
     pub fn set_save_dir(&mut self, dir: PathBuf) {
+        // クリップ保存先ディレクトリ
         self.save_dir = dir;
     }
 
@@ -162,22 +173,26 @@ impl FfmpegProcess {
             .map_err(|e| e.to_string())?;
 
         self.child = Some(child);
+        // プロセスハンドルを保存しておく
 
         self.ram_dir = Some(dir.clone());
+        // 一時保存用ディレクトリのパス
 
         let save_path = dir.join(".trigger_save");
         let quit_path = dir.join(".trigger_quit");
-        // ファイルトリガー監視タスクを起動
+        // 保存や停止を外部から指示するための監視タスク
         tauri::async_runtime::spawn(async move {
             use tokio::time::{sleep, Duration};
             loop {
                 if fs::metadata(&save_path).await.is_ok() {
+                    // .trigger_save を検知したらバッファを保存
                     println!("Save trigger detected, saving current buffer");
                     let _ = fs::remove_file(&save_path).await;
                     let mut p = shared.lock().await;
                     let _ = p.save().await;
                 }
                 if fs::metadata(&quit_path).await.is_ok() {
+                    // .trigger_quit を検知したらプロセスを終了
                     println!("Quit trigger detected, stopping ffmpeg process");
                     let _ = fs::remove_file(&quit_path).await;
                     let mut p = shared.lock().await;
@@ -197,6 +212,7 @@ impl FfmpegProcess {
             let _ = child.kill(); // プロセス終了を試みる
         }
         if let Some(dir) = &self.ram_dir {
+            // 作成した一時ディレクトリを削除
             let _ = fs::remove_dir_all(dir).await;
         }
         self.ram_device = None;
@@ -213,7 +229,7 @@ impl FfmpegProcess {
             return Err("ffmpeg not running".into());
         };
 
-        let offset = -(self.wrap_count as i32 - 1);
+        let offset = -(self.wrap_count as i32 - 1); // ラップしている分の開始位置
         let dur = self.segment_seconds * (self.wrap_count - 1);
         let ts = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
         let mut out = self.save_dir.clone();
@@ -237,13 +253,14 @@ impl FfmpegProcess {
                 "+faststart",
                 &out.to_string_lossy(),
             ])
-            .output()
+            .output() // 実際に ffmpeg を実行
             .map_err(|e| e.to_string())?;
         if !output.status.success() {
             // ffmpeg が失敗した場合は stderr を返す
             return Err(String::from_utf8_lossy(&output.stderr).to_string());
         }
 
+        // 正常終了した場合は保存先パスを返す
         Ok(out)
     }
 }
@@ -251,6 +268,7 @@ impl FfmpegProcess {
 /// 複数タスク間で ffmpeg プロセスを共有するための型
 pub type SharedFfmpegProcess = Arc<AsyncMutex<FfmpegProcess>>;
 pub struct FfmpegState(pub SharedFfmpegProcess);
+// アプリ全体で共有するためのラッパー型
 
 pub async fn write_clip_metadata(
     db_path: &std::path::Path,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,5 +3,5 @@
 
 fn main() {
     // ライブラリ側のエントリポイントを呼び出すだけ
-    lol_clip_tool_lib::run()
+    lol_clip_tool_lib::run() // 実際の処理は lib 側に実装
 }

--- a/src-tauri/src/obs.rs
+++ b/src-tauri/src/obs.rs
@@ -4,6 +4,7 @@ use tokio_tungstenite::{connect_async, tungstenite::Message, WebSocketStream};
 use tokio::net::TcpStream;
 use futures_util::{SinkExt, StreamExt};
 use std::sync::{Arc, Mutex};
+// WebSocket 通信に必要なクレート群をインポート
 
 pub type WsType = WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
 
@@ -11,10 +12,12 @@ pub type WsType = WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
 pub struct ObsWsClient {
     ws: WsType,
 }
+// 単純なラッパーで WebSocket ストリームを保持
 
 impl ObsWsClient {
     /// OBS WebSocket に接続し Identify ハンドシェイクを行う
     pub async fn connect_and_identify(url: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        // OBS WebSocket へ接続
         let (mut ws_stream, _) = connect_async(url).await?;
         // 1. Hello を受信
         let msg = ws_stream.next().await;
@@ -56,11 +59,12 @@ impl ObsWsClient {
             }
         });
         self.ws.send(Message::Text(req.to_string().into())).await?;
-        Ok(())
+        Ok(()) // エラーは上位で処理
     }
 
     /// コマンド送信後、レスポンスを待って値を返す
     pub async fn send_request(&mut self, command: &str) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+        // リクエストを投げてレスポンスを待つ
         let req = json!({
             "op": 6,
             "d": {
@@ -73,7 +77,7 @@ impl ObsWsClient {
             let val: serde_json::Value = serde_json::from_str(&resp)?;
             Ok(val)
         } else {
-            Err("No response".into())
+            Err("No response".into()) // 応答が無い場合
         }
     }
 }
@@ -83,6 +87,7 @@ pub struct ObsWsState(pub SharedObsWsClient);
 
 /// Send OBS command ensuring connection is established
 pub async fn send_obs_command_wrapper(shared: SharedObsWsClient, command: &str) -> Result<(), String> {
+    // 接続が無い場合は自動で接続を行う
     let mut needs_connect = false;
     {
         let client_guard = shared.lock().unwrap();
@@ -110,7 +115,7 @@ pub async fn send_obs_command_wrapper(shared: SharedObsWsClient, command: &str) 
         let mut guard = shared.lock().unwrap();
         *guard = client_opt;
     }
-    result
+    result // 結果をそのまま返す
 }
 
 /// Send OBS command and return the response
@@ -141,11 +146,12 @@ pub async fn send_obs_request_wrapper(shared: SharedObsWsClient, command: &str) 
         let mut guard = shared.lock().unwrap();
         *guard = client_opt;
     }
-    result
+    result // 正常時は Ok(())
 }
 
 /// OBS 側の録画保存先ディレクトリを変更する
 pub async fn set_record_directory(shared: SharedObsWsClient, dir: &str) -> Result<(), String> {
+    // ディレクトリ設定前に接続確認
     let mut needs_connect = false;
     {
         let client_guard = shared.lock().unwrap();

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -2,6 +2,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+// 設定ファイルの保存先などに利用
 
 use crate::RecordingMode;
 
@@ -18,6 +19,7 @@ pub struct AppSettings {
     #[serde(default = "default_save_dir")]
     pub save_dir: String,
 }
+// アプリ起動時の基本設定をまとめる
 
 impl Default for AppSettings {
     fn default() -> Self {
@@ -53,10 +55,12 @@ pub fn save_settings(path: &Path, settings: &AppSettings) -> std::io::Result<()>
         fs::create_dir_all(parent)?;
     }
     // 整形した JSON で書き出す
+    // 書き込み処理を実行
     fs::write(path, serde_json::to_string_pretty(settings).unwrap())
 }
 
 #[derive(Clone)]
 pub struct SettingsPath(pub PathBuf);
+// 設定ファイルのパスを保持するだけのラッパー
 
 pub struct SettingsState(pub std::sync::Arc<std::sync::Mutex<AppSettings>>);

--- a/src/main.js
+++ b/src/main.js
@@ -3,4 +3,4 @@
 window.addEventListener("DOMContentLoaded", () => {
   // 動的な処理が必要になった場合はここに追記する
   // 例: 初期化コードやイベントリスナー登録
-});
+}); // DOM 準備完了後に実行

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,6 +1,7 @@
 // Rust 側との通信に使用する invoke を取得
 const { invoke } = window.__TAURI__.core;
 const { open } = window.__TAURI__.dialog;
+// Tauri API の基本機能を利用
 
 // input 要素から整数値を取得し、最小値チェックを行うユーティリティ
 function getInt(id, min = 1) {
@@ -139,7 +140,7 @@ async function updateStatus() {
   if (saveBtn) {
     saveBtn.disabled = !status.replay_buffer_running;
   }
-}
+} // updateStatus end
 
 // 画面のログ欄へテキストを追加
 function logEvent(message) {
@@ -169,7 +170,7 @@ async function loadSettings() {
   if (toggle) toggle.checked = s.recording_mode === 'Shell';
   const dir = document.getElementById('saveDirInput');
   if (dir) dir.value = s.save_dir;
-}
+} // loadSettings end
 
 // ffmpeg が利用可能なデバイス一覧を取得してセレクトボックスへ展開
 async function loadDevices() {
@@ -195,7 +196,7 @@ async function loadDevices() {
   } catch (e) {
     logEvent(`⚠️ デバイス情報の取得に失敗しました: ${e}`);
   }
-}
+} // loadDevices end
 
 // 画面で指定した値を設定ファイルへ保存
 async function saveSettings() {
@@ -224,4 +225,4 @@ async function saveSettings() {
   await invoke('save_settings_cmd', { settings });
   await invoke('set_saved_directory', { dir: settings.save_dir });
   logEvent('⚙️ 設定を保存しました');
-}
+} // saveSettings end

--- a/src/videos.js
+++ b/src/videos.js
@@ -1,12 +1,13 @@
 // 保存済み動画一覧を取得しテーブル表示するスクリプト
 const { invoke } = window.__TAURI__.core;
+// Tauri のバックエンドと通信するための関数
 
 // テーブルへ動画情報を動的に展開
 async function loadVideos() {
   // Rust 側から動画一覧を取得
   const list = await invoke('list_saved_videos');
   const tbody = document.getElementById('videoTableBody');
-  tbody.innerHTML = '';
+  tbody.innerHTML = ''; // 一度内容をクリア
   list.forEach((info) => {
     const tr = document.createElement('tr');
     tr.className = 'border-b border-gray-200';
@@ -32,7 +33,7 @@ async function loadVideos() {
 
     tbody.appendChild(tr);
   });
-}
+} // loadVideos end
 
 // ページ表示後に動画一覧を読み込む
 window.addEventListener('DOMContentLoaded', loadVideos);

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,6 +1,7 @@
 // 動画再生ページでクリップのメタデータを表示する処理群
 const { convertFileSrc, invoke } = window.__TAURI__.core;
 const {} = window.__TAURI__.path;
+// 動画ファイルパスの変換や Rust コマンド呼び出しに使用
 
 // イベント種類ごとに色を決定するヘルパー
 function eventColor(name) {
@@ -15,6 +16,7 @@ function eventColor(name) {
       return "#6c757d";
   }
 }
+// 取得したイベント名を色に変換
 
 
 // イベント内容を分かりやすいテキストに変換
@@ -28,6 +30,7 @@ function formatEvent(e) {
       return e.EventName;
   }
 }
+// イベント表示用に整形
 
 // プレイヤー初期化とイベントメタデータの読み込み
 async function init() {
@@ -81,7 +84,7 @@ async function init() {
       m.title = `${formatEvent(e)}\n${JSON.stringify(e, null, 2)}`;
       markers.appendChild(m);
     });
-  }
+  } // addMarkers end
 
 
   // 再生位置に合わせて表示するイベントを更新
@@ -105,7 +108,7 @@ async function init() {
         1
       )}s)`;
     }
-  }
+  } // update end
 
   player.on('loadedmetadata', addMarkers); // 再生準備完了時にマーカー追加
   player.on('timeupdate', update); // 再生位置が変わるたびに呼び出し
@@ -113,4 +116,4 @@ async function init() {
 }
 
 // DOM 解析後に初期化処理を実行
-window.addEventListener('DOMContentLoaded', init);
+window.addEventListener('DOMContentLoaded', init); // ページ読み込み時


### PR DESCRIPTION
## Summary
- add explanatory comments in Japanese throughout Rust sources
- document code behavior in JavaScript files

## Testing
- `cargo check` *(fails: gobject-2.0 not found)*
- `pnpm --version`

------
https://chatgpt.com/codex/tasks/task_e_6853569588c8832cba78352dcacd2612