### PR TITLE
Ensure recording mode matches page

### DIFF
--- a/src/ffmpeg.html
+++ b/src/ffmpeg.html
@@ -94,6 +94,16 @@
       </div>
     </main>
 
-    <script>window.addEventListener("DOMContentLoaded",()=>{const t=document.getElementById("modeToggle");if(t){t.checked=true;t.disabled=true;}});</script>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const t = document.getElementById("modeToggle");
+        if (t) {
+          t.checked = true;
+          t.disabled = true;
+        }
+        // ページ遷移時にアプリの録画モードも ffmpeg に更新する
+        window.__TAURI__.core.invoke("set_recording_mode", { mode: "Shell" });
+      });
+    </script>
   </body>
 </html>

--- a/src/obs.html
+++ b/src/obs.html
@@ -68,6 +68,16 @@
       </div>
     </main>
 
-    <script>window.addEventListener("DOMContentLoaded",()=>{const t=document.getElementById("modeToggle");if(t){t.checked=false;t.disabled=true;}});</script>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const t = document.getElementById("modeToggle");
+        if (t) {
+          t.checked = false;
+          t.disabled = true;
+        }
+        // ページ遷移時にアプリの録画モードも OBS に更新する
+        window.__TAURI__.core.invoke("set_recording_mode", { mode: "Obs" });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update embedded scripts in `obs.html` and `ffmpeg.html`
- when each page loads, call `set_recording_mode` so the app state reflects the page's mode

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `gobject-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68536d254c4c832c8eb00ca67c1065f2