### PR TITLE
Add desktop notifications using Tauri plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@tauri-apps/cli": "^2"
   },
   "dependencies": {
-    "@tauri-apps/plugin-dialog": "~2.2.2"
+    "@tauri-apps/plugin-dialog": "~2.2.2",
+    "@tauri-apps/plugin-notification": "^2.2.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ~2.2.2
         version: 2.2.2
+      '@tauri-apps/plugin-notification':
+        specifier: ^2.2.3
+        version: 2.2.3
     devDependencies:
       '@tauri-apps/cli':
         specifier: ^2
@@ -95,6 +98,9 @@ packages:
   '@tauri-apps/plugin-dialog@2.2.2':
     resolution: {integrity: sha512-Pm9qnXQq8ZVhAMFSEPwxvh+nWb2mk7LASVlNEHYaksHvcz8P6+ElR5U5dNL9Ofrm+uwhh1/gYKWswK8JJJAh6A==}
 
+  '@tauri-apps/plugin-notification@2.2.3':
+    resolution: {integrity: sha512-IlMdSVFsrKg0eIHBloFFosnWbbz6JdwBywfZrYZnE1+acgXvNS3T1YB5w9R6UXw+KKQ94ODBu7JF7a1YUiAK6A==}
+
 snapshots:
 
   '@tauri-apps/api@2.5.0': {}
@@ -147,5 +153,9 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.5.0
 
   '@tauri-apps/plugin-dialog@2.2.2':
+    dependencies:
+      '@tauri-apps/api': 2.5.0
+
+  '@tauri-apps/plugin-notification@2.2.3':
     dependencies:
       '@tauri-apps/api': 2.5.0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2082,6 +2082,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tokio",
  "tokio-tungstenite",
@@ -2092,6 +2093,18 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b95dfb34071d1592b45622bf93e315e3a72d414b6782aca9a015c12bec367ef"
+dependencies = [
+ "cc",
+ "objc2 0.6.1",
+ "objc2-foundation 0.3.1",
+ "time",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2247,6 +2260,20 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify-rust"
+version = "4.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "num-conv"
@@ -2822,7 +2849,7 @@ checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.9.0",
- "quick-xml",
+ "quick-xml 0.32.0",
  "serde",
  "time",
 ]
@@ -2957,6 +2984,15 @@ name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
@@ -4106,6 +4142,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c87f171cdb35c3aa8f17e8dfd84c1b9f68eb4086ec16a5a1b9f13b5541c574"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.12",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4223,6 +4278,18 @@ dependencies = [
  "embed-resource",
  "indexmap 2.9.0",
  "toml",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.12",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,4 +30,5 @@ chrono = "0.4.41"
 dirs = "6.0.0"
 tauri-plugin-fs = "2.3.0"
 tauri-plugin-dialog = "2"
+tauri-plugin-notification = "2"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "dialog:default"
+    "dialog:default",
+    "notification:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use tokio::process::Command;
 use std::process::Stdio;
 use reqwest::Client;
 use tauri::{async_runtime::spawn, Manager};
+use tauri_plugin_notification::NotificationExt;
 use std::path::PathBuf;
 
 mod settings; // 設定関連
@@ -58,6 +59,18 @@ fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+fn notify(app: &tauri::AppHandle, title: &str, body: &str) {
+    if let Err(e) = app
+        .notification()
+        .builder()
+        .title(title)
+        .body(body)
+        .show()
+    {
+        eprintln!("failed to show notification: {}", e);
+    }
+}
+
 #[tauri::command]
 fn get_status(state: tauri::State<AppStatusState>) -> AppStatus {
     state.0.lock().unwrap().clone()
@@ -74,6 +87,7 @@ async fn set_recording_mode(state: tauri::State<'_, AppStatusState>, mode: Recor
 
 #[tauri::command]
 async fn start_recording(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppStatusState>,
     obs_state: tauri::State<'_, ObsWsState>,
     ffmpeg_state: tauri::State<'_, FfmpegState>,
@@ -87,7 +101,7 @@ async fn start_recording(
         lock.replay_buffer_running = false;
         lock.recording_mode.clone()
     };
-    match mode {
+    let res = match mode {
         RecordingMode::Obs => {
             spawn(send_obs_command_wrapper(obs_state.0.clone(), "StartRecord")); // OBS 録画開始
             Ok(())
@@ -98,11 +112,14 @@ async fn start_recording(
             let mut proc = shared.lock().await;
             proc.start(shared.clone()).await
         }
-    }
+    };
+    notify(&app, "録画開始", "録画を開始しました");
+    res
 }
 
 #[tauri::command]
 async fn stop_recording(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppStatusState>,
     obs_state: tauri::State<'_, ObsWsState>,
     ffmpeg_state: tauri::State<'_, FfmpegState>,
@@ -116,7 +133,7 @@ async fn stop_recording(
         lock.replay_buffer_running = false;
         lock.recording_mode.clone()
     };
-    match mode {
+    let res = match mode {
         RecordingMode::Obs => {
             spawn(send_obs_command_wrapper(obs_state.0.clone(), "StopRecord")); // OBS 停止
             Ok(())
@@ -125,11 +142,14 @@ async fn stop_recording(
             let mut proc = ffmpeg_state.0.lock().await;
             proc.stop().await
         }
-    }
+    };
+    notify(&app, "録画停止", "録画を停止しました");
+    res
 }
 
 #[tauri::command]
 async fn start_replay_buffer(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppStatusState>,
     obs_state: tauri::State<'_, ObsWsState>,
     ffmpeg_state: tauri::State<'_, FfmpegState>,
@@ -141,7 +161,7 @@ async fn start_replay_buffer(
         lock.replay_buffer_running = true;
         lock.recording_mode.clone()
     };
-    match mode {
+    let res = match mode {
         RecordingMode::Obs => {
             spawn(send_obs_command_wrapper(obs_state.0.clone(), "StartReplayBuffer")); // OBS 側でリプレイ開始
             Ok(())
@@ -152,11 +172,14 @@ async fn start_replay_buffer(
             let mut proc = shared.lock().await;
             proc.start(shared.clone()).await
         }
-    }
+    };
+    notify(&app, "リプレイバッファ開始", "リプレイバッファを開始しました");
+    res
 }
 
 #[tauri::command]
 async fn stop_replay_buffer(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppStatusState>,
     obs_state: tauri::State<'_, ObsWsState>,
     ffmpeg_state: tauri::State<'_, FfmpegState>,
@@ -168,7 +191,7 @@ async fn stop_replay_buffer(
         lock.replay_buffer_running = false;
         lock.recording_mode.clone()
     };
-    match mode {
+    let res = match mode {
         RecordingMode::Obs => {
             spawn(send_obs_command_wrapper(obs_state.0.clone(), "StopReplayBuffer")); // OBS リプレイ停止
             Ok(())
@@ -177,17 +200,20 @@ async fn stop_replay_buffer(
             let mut proc = ffmpeg_state.0.lock().await;
             proc.stop().await
         }
-    }
+    };
+    notify(&app, "リプレイバッファ停止", "リプレイバッファを停止しました");
+    res
 }
 
 #[tauri::command]
 async fn save_replay_buffer(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppStatusState>,
     obs_state: tauri::State<'_, ObsWsState>,
     ffmpeg_state: tauri::State<'_, FfmpegState>,
 ) -> Result<(), String> {
     let mode = { state.0.lock().unwrap().recording_mode.clone() };
-    match mode {
+    let res = match mode {
         RecordingMode::Obs => {
             spawn(send_obs_command_wrapper(obs_state.0.clone(), "SaveReplayBuffer")); // OBS に保存指示
             Ok(())
@@ -196,7 +222,9 @@ async fn save_replay_buffer(
             let mut proc = ffmpeg_state.0.lock().await;
             proc.save().await.map(|_| ())
         }
-    }
+    };
+    notify(&app, "クリップ保存", "リプレイバッファを保存しました");
+    res
 }
 
 #[tauri::command]
@@ -318,6 +346,7 @@ async fn save_settings_cmd(
 
 #[tauri::command]
 async fn start_ffmpeg_replay(
+    app: tauri::AppHandle,
     status_state: tauri::State<'_, AppStatusState>,
     state: tauri::State<'_, FfmpegState>,
     segment_seconds: Option<u32>,
@@ -357,11 +386,14 @@ async fn start_ffmpeg_replay(
     if let Some(b) = bitrate {
         proc.set_bitrate(b);
     }
-    proc.start(shared).await
+    let res = proc.start(shared).await;
+    notify(&app, "ffmpeg バッファ開始", "リプレイバッファを開始しました");
+    res
 }
 
 #[tauri::command]
 async fn stop_ffmpeg_replay(
+    app: tauri::AppHandle,
     status_state: tauri::State<'_, AppStatusState>,
     state: tauri::State<'_, FfmpegState>,
 ) -> Result<(), String> {
@@ -370,13 +402,17 @@ async fn stop_ffmpeg_replay(
         let mut status = status_state.0.lock().unwrap();
         status.replay_buffer_running = false;
     }
-    proc.stop().await
+    let res = proc.stop().await;
+    notify(&app, "ffmpeg バッファ停止", "リプレイバッファを停止しました");
+    res
 }
 
 #[tauri::command]
-async fn save_ffmpeg_clip(state: tauri::State<'_, FfmpegState>) -> Result<(), String> {
+async fn save_ffmpeg_clip(app: tauri::AppHandle, state: tauri::State<'_, FfmpegState>) -> Result<(), String> {
     let mut proc = state.0.lock().await;
-    proc.save().await.map(|_| ())
+    let res = proc.save().await.map(|_| ());
+    notify(&app, "クリップ保存", "リプレイバッファを保存しました");
+    res
 }
 
 #[derive(Serialize)]
@@ -551,6 +587,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_notification::init())
         .invoke_handler(tauri::generate_handler![
             get_status,
             set_recording_mode,
@@ -621,6 +658,7 @@ pub fn run() {
             let obs_ws_client_clone = obs_ws_client.clone();
             let ffmpeg_process_clone = ffmpeg_process.clone();
             let db_path_clone = db_state.clone();
+            let app_clone = _app.app_handle();
 
             tauri::async_runtime::spawn(async move {
                 poll_lol_events(move |all_data: &AllGameData, new_events: Vec<LolEvent>| {
@@ -653,6 +691,7 @@ pub fn run() {
                                                     eprintln!("Failed to send Multikill command to OBS: {}", e);
                                                 } else {
                                                     println!("Sent Multikill command to OBS");
+                                                    notify(&app_clone, "クリップ保存", "リプレイバッファを保存しました");
                                                 }
                                             });
                                         }
@@ -675,6 +714,7 @@ pub fn run() {
                                                             if let Err(e) = write_clip_metadata(&db_path, &path, &relevant_events, clip_start).await {
                                                                 eprintln!("Failed to write metadata: {}", e);
                                                             }
+                                                            notify(&app_clone, "クリップ保存", "リプレイバッファを保存しました");
                                                         }
                                                         Err(e) => {
                                                             eprintln!("Failed to save clip: {}", e);
@@ -701,29 +741,31 @@ pub fn run() {
                                 match mode {
                                     RecordingMode::Obs => {
                                         let obs_client_clone = obs_ws_client_clone.clone();
-                                        tauri::async_runtime::spawn(async move {
-                                            if let Err(e) = send_obs_command_wrapper(obs_client_clone, "StartRecord").await {
-                                                eprintln!("Failed to start OBS recording: {}", e);
-                                            } else {
-                                                println!("Started OBS recording");
-                                            }
-                                        });
-                                    }
-                                    RecordingMode::Shell => {
-                                        let ffmpeg_clone = ffmpeg_process_clone.clone();
-                                        tauri::async_runtime::spawn({
-                                            let ffmpeg_process_clone = ffmpeg_process_clone.clone();
-                                            async move {
-                                                if let Err(e) = ffmpeg_clone.lock().await.start(ffmpeg_process_clone).await {
-                                                    eprintln!("Failed to start ffmpeg recording: {}", e);
+                                            tauri::async_runtime::spawn(async move {
+                                                if let Err(e) = send_obs_command_wrapper(obs_client_clone, "StartRecord").await {
+                                                    eprintln!("Failed to start OBS recording: {}", e);
                                                 } else {
-                                                    println!("Started ffmpeg recording");
+                                                    println!("Started OBS recording");
+                                                    notify(&app_clone, "録画開始", "OBS録画を開始しました");
                                                 }
-                                            }
-                                        });
+                                            });
+                                        }
+                                        RecordingMode::Shell => {
+                                            let ffmpeg_clone = ffmpeg_process_clone.clone();
+                                            tauri::async_runtime::spawn({
+                                                let ffmpeg_process_clone = ffmpeg_process_clone.clone();
+                                                async move {
+                                                    if let Err(e) = ffmpeg_clone.lock().await.start(ffmpeg_process_clone).await {
+                                                        eprintln!("Failed to start ffmpeg recording: {}", e);
+                                                    } else {
+                                                        println!("Started ffmpeg recording");
+                                                        notify(&app_clone, "録画開始", "ffmpeg録画を開始しました");
+                                                    }
+                                                }
+                                            });
+                                        }
                                     }
                                 }
-                            }
 
                             // ゲーム終了時にOBSかffmpegの録画を停止
                             "GameEnd" => {
@@ -739,26 +781,28 @@ pub fn run() {
                                 match mode {
                                     RecordingMode::Obs => {
                                         let obs_client_clone = obs_ws_client_clone.clone();
-                                        tauri::async_runtime::spawn(async move {
-                                            if let Err(e) = send_obs_command_wrapper(obs_client_clone, "StopRecord").await {
-                                                eprintln!("Failed to stop OBS recording: {}", e);
-                                            } else {
-                                                println!("Stopped OBS recording");
-                                            }
-                                        });
-                                    }
-                                    RecordingMode::Shell => {
-                                        let ffmpeg_clone = ffmpeg_process_clone.clone();
-                                        tauri::async_runtime::spawn(async move {
-                                            if let Err(e) = ffmpeg_clone.lock().await.stop().await {
-                                                eprintln!("Failed to stop ffmpeg recording: {}", e);
-                                            } else {
-                                                println!("Stopped ffmpeg recording");
-                                            }
-                                        });
+                                            tauri::async_runtime::spawn(async move {
+                                                if let Err(e) = send_obs_command_wrapper(obs_client_clone, "StopRecord").await {
+                                                    eprintln!("Failed to stop OBS recording: {}", e);
+                                                } else {
+                                                    println!("Stopped OBS recording");
+                                                    notify(&app_clone, "録画停止", "OBS録画を停止しました");
+                                                }
+                                            });
+                                        }
+                                        RecordingMode::Shell => {
+                                            let ffmpeg_clone = ffmpeg_process_clone.clone();
+                                            tauri::async_runtime::spawn(async move {
+                                                if let Err(e) = ffmpeg_clone.lock().await.stop().await {
+                                                    eprintln!("Failed to stop ffmpeg recording: {}", e);
+                                                } else {
+                                                    println!("Stopped ffmpeg recording");
+                                                    notify(&app_clone, "録画停止", "ffmpeg録画を停止しました");
+                                                }
+                                            });
+                                        }
                                     }
                                 }
-                            }
                             _ => {
                                 println!("Unhandled event: {} at {}", event.EventName, event.EventTime);
                             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -658,7 +658,7 @@ pub fn run() {
             let obs_ws_client_clone = obs_ws_client.clone();
             let ffmpeg_process_clone = ffmpeg_process.clone();
             let db_path_clone = db_state.clone();
-            let app_clone = _app.app_handle();
+            let app_clone = _app.handle().clone();
 
             tauri::async_runtime::spawn(async move {
                 poll_lol_events(move |all_data: &AllGameData, new_events: Vec<LolEvent>| {
@@ -686,12 +686,13 @@ pub fn run() {
                                     match mode {
                                         RecordingMode::Obs => {
                                             let obs_client_clone = obs_ws_client_clone.clone();
+                                            let app_handle = app_clone.clone();
                                             tauri::async_runtime::spawn(async move {
                                                 if let Err(e) = send_obs_command_wrapper(obs_client_clone, "SaveReplayBuffer").await {
                                                     eprintln!("Failed to send Multikill command to OBS: {}", e);
                                                 } else {
                                                     println!("Sent Multikill command to OBS");
-                                                    notify(&app_clone, "クリップ保存", "リプレイバッファを保存しました");
+                                                    notify(&app_handle, "クリップ保存", "リプレイバッファを保存しました");
                                                 }
                                             });
                                         }
@@ -699,6 +700,7 @@ pub fn run() {
                                             let ffmpeg_clone = ffmpeg_process_clone.clone();
                                             let event_clone = event.clone();
                                             let events_snapshot = all_data.events.events.clone();
+                                            let app_handle = app_clone.clone();
                                             tauri::async_runtime::spawn({
                                                 let db_path = db_path_clone.0.clone();
                                                 async move {
@@ -714,7 +716,7 @@ pub fn run() {
                                                             if let Err(e) = write_clip_metadata(&db_path, &path, &relevant_events, clip_start).await {
                                                                 eprintln!("Failed to write metadata: {}", e);
                                                             }
-                                                            notify(&app_clone, "クリップ保存", "リプレイバッファを保存しました");
+                                                            notify(&app_handle, "クリップ保存", "リプレイバッファを保存しました");
                                                         }
                                                         Err(e) => {
                                                             eprintln!("Failed to save clip: {}", e);
@@ -741,17 +743,19 @@ pub fn run() {
                                 match mode {
                                     RecordingMode::Obs => {
                                         let obs_client_clone = obs_ws_client_clone.clone();
+                                            let app_handle = app_clone.clone();
                                             tauri::async_runtime::spawn(async move {
                                                 if let Err(e) = send_obs_command_wrapper(obs_client_clone, "StartRecord").await {
                                                     eprintln!("Failed to start OBS recording: {}", e);
                                                 } else {
                                                     println!("Started OBS recording");
-                                                    notify(&app_clone, "録画開始", "OBS録画を開始しました");
+                                                    notify(&app_handle, "録画開始", "OBS録画を開始しました");
                                                 }
                                             });
                                         }
                                         RecordingMode::Shell => {
                                             let ffmpeg_clone = ffmpeg_process_clone.clone();
+                                            let app_handle = app_clone.clone();
                                             tauri::async_runtime::spawn({
                                                 let ffmpeg_process_clone = ffmpeg_process_clone.clone();
                                                 async move {
@@ -759,7 +763,7 @@ pub fn run() {
                                                         eprintln!("Failed to start ffmpeg recording: {}", e);
                                                     } else {
                                                         println!("Started ffmpeg recording");
-                                                        notify(&app_clone, "録画開始", "ffmpeg録画を開始しました");
+                                                        notify(&app_handle, "録画開始", "ffmpeg録画を開始しました");
                                                     }
                                                 }
                                             });
@@ -781,23 +785,25 @@ pub fn run() {
                                 match mode {
                                     RecordingMode::Obs => {
                                         let obs_client_clone = obs_ws_client_clone.clone();
+                                            let app_handle = app_clone.clone();
                                             tauri::async_runtime::spawn(async move {
                                                 if let Err(e) = send_obs_command_wrapper(obs_client_clone, "StopRecord").await {
                                                     eprintln!("Failed to stop OBS recording: {}", e);
                                                 } else {
                                                     println!("Stopped OBS recording");
-                                                    notify(&app_clone, "録画停止", "OBS録画を停止しました");
+                                                    notify(&app_handle, "録画停止", "OBS録画を停止しました");
                                                 }
                                             });
                                         }
                                         RecordingMode::Shell => {
                                             let ffmpeg_clone = ffmpeg_process_clone.clone();
+                                            let app_handle = app_clone.clone();
                                             tauri::async_runtime::spawn(async move {
                                                 if let Err(e) = ffmpeg_clone.lock().await.stop().await {
                                                     eprintln!("Failed to stop ffmpeg recording: {}", e);
                                                 } else {
                                                     println!("Stopped ffmpeg recording");
-                                                    notify(&app_clone, "録画停止", "ffmpeg録画を停止しました");
+                                                    notify(&app_handle, "録画停止", "ffmpeg録画を停止しました");
                                                 }
                                             });
                                         }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,6 +1,7 @@
 // Rust 側との通信に使用する invoke を取得
 const { invoke } = window.__TAURI__.core;
 const { open } = window.__TAURI__.dialog;
+import { isPermissionGranted, requestPermission } from '@tauri-apps/plugin-notification';
 // Tauri API の基本機能を利用
 
 // input 要素から整数値を取得し、最小値チェックを行うユーティリティ
@@ -20,6 +21,9 @@ window.addEventListener("DOMContentLoaded", async () => {
     await loadDevices(); // ffmpeg 用のデバイス一覧を取得
   }
   await loadSettings(); // 保存済み設定を画面へ反映
+  if (!(await isPermissionGranted())) {
+    await requestPermission();
+  }
   // 各ボタンにイベントリスナーを設定
   document.getElementById('modeToggle')?.addEventListener('change', async (e) => {
     const mode = e.target.checked ? 'Shell' : 'Obs';


### PR DESCRIPTION
## Summary
- install notification plugin for Tauri
- enable `notification:default` capability
- register plugin in the backend and add helper for notifications
- show notifications when recording and replay buffer actions occur
- request notification permission in settings page

## Testing
- `pnpm install`
- `cargo fetch --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853769b8110832c89753517bbfd3a67