### PR TITLE
Implement game/video time synchronization

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,4 +1,5 @@
 use crate::lol::LolEvent;
+use crate::timesync::{TimeSnapshot, TimedEvent};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tokio::fs;
@@ -25,23 +26,24 @@ pub async fn init_db(path: &Path) -> Result<(), String> {
 pub async fn write_clip_metadata(
     _db_path: &Path,
     video_path: &Path,
-    events: &[LolEvent],
+    time_map: &[TimeSnapshot],
+    events: &[TimedEvent],
     clip_start: f64,
 ) -> Result<(), String> {
-    // 出力ファイル名を json に変換
     let out_path = video_path.with_extension("json");
     let events_with_offset: Vec<EventWithOffset> = events
         .iter()
-        .cloned()
         .map(|ev| EventWithOffset {
-            // 各イベントにオフセットを付与
-            event: ev.clone(),
-            offset: ev.EventTime - clip_start,
+            event: ev.event.clone(),
+            real_time: ev.real_time,
+            offset: ev.real_time - clip_start,
         })
         .collect();
-    // JSON 文字列へ変換
-    let json = serde_json::to_string_pretty(&events_with_offset).map_err(|e| e.to_string())?;
-    // ファイルへ書き出し
+    let meta = ClipMetadata {
+        events: events_with_offset,
+        time_map: time_map.to_vec(),
+    };
+    let json = serde_json::to_string_pretty(&meta).map_err(|e| e.to_string())?;
     fs::write(out_path, json).await.map_err(|e| e.to_string())
 }
 
@@ -49,18 +51,25 @@ pub async fn write_clip_metadata(
 pub struct EventWithOffset {
     #[serde(flatten)]
     pub event: LolEvent,
+    /// Absolute real time (seconds since Unix epoch)
+    pub real_time: f64,
     pub offset: f64,
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct ClipMetadata {
+    pub events: Vec<EventWithOffset>,
+    pub time_map: Vec<TimeSnapshot>,
+}
+
 // クリップ内でのイベント発生位置を保持
 
 /// Read clip metadata from the JSON file written by `write_clip_metadata`.
-pub async fn get_clip_events(_db_path: &Path, path: &Path) -> Result<Vec<EventWithOffset>, String> {
-    // JSON ファイルを開き内容を文字列で取得
+pub async fn read_clip_metadata(_db_path: &Path, path: &Path) -> Result<ClipMetadata, String> {
     let json_path = path.with_extension("json");
     let contents = fs::read_to_string(json_path)
         .await
         .map_err(|e| e.to_string())?;
-    // JSON を構造体へ変換
     serde_json::from_str(&contents).map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -283,13 +283,3 @@ pub type SharedFfmpegProcess = Arc<AsyncMutex<FfmpegProcess>>;
 pub struct FfmpegState(pub SharedFfmpegProcess);
 // アプリ全体で共有するためのラッパー型
 
-pub async fn write_clip_metadata(
-    db_path: &std::path::Path,
-    path: &std::path::Path,
-    events: &[LolEvent],
-    clip_start: f64,
-) -> Result<(), String> {
-    // 保存したクリップに紐づくイベント情報をDBへ書き込む
-    // crate::db::write_clip_metadata(db_path, path, events, clip_start).await
-    Ok(())
-}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,12 +16,14 @@ mod ffmpeg; // ffmpeg 管理
 mod lol; // LoL API ラッパー
 mod obs; // OBS WebSocket クライアント
 mod settings; // 設定関連 // SQLite アクセス
+mod timesync;
 
-use db::{cleanup_orphan_clips, get_clip_events, init_db, list_clips, DbPath};
-use ffmpeg::{write_clip_metadata, FfmpegProcess, FfmpegState, SharedFfmpegProcess};
+use db::{cleanup_orphan_clips, read_clip_metadata, write_clip_metadata, init_db, list_clips, DbPath};
+use ffmpeg::{FfmpegProcess, FfmpegState, SharedFfmpegProcess};
 use lol::{AllGameData, LolEvent};
 use obs::{send_obs_command_wrapper, set_record_directory, ObsWsState, SharedObsWsClient};
-use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState}; // DB 操作用
+use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState};
+use timesync::{TimeSyncState, TimeSnapshot, TimedEvent, TimeSyncData};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 enum GameState {
@@ -294,8 +296,8 @@ async fn list_saved_videos(
 async fn get_clip_metadata(
     path: String,
     db: tauri::State<'_, DbPath>,
-) -> Result<Vec<db::EventWithOffset>, String> {
-    get_clip_events(&db.0, std::path::Path::new(&path)).await
+) -> Result<db::ClipMetadata, String> {
+    read_clip_metadata(&db.0, std::path::Path::new(&path)).await
 }
 
 #[tauri::command]
@@ -389,9 +391,37 @@ async fn stop_ffmpeg_replay(
 }
 
 #[tauri::command]
-async fn save_ffmpeg_clip(state: tauri::State<'_, FfmpegState>) -> Result<(), String> {
+async fn save_ffmpeg_clip(
+    state: tauri::State<'_, FfmpegState>,
+    timesync: tauri::State<'_, TimeSyncState>,
+    db: tauri::State<'_, DbPath>,
+) -> Result<(), String> {
+    let start_real = chrono::Utc::now().timestamp_millis() as f64 / 1000.0;
     let mut proc = state.0.lock().await;
-    proc.save().await.map(|_| ())
+    match proc.save().await {
+        Ok(path) => {
+            let dur = proc.segment_seconds * 10;
+            let clip_start_real = start_real - dur as f64;
+            let ts = {
+                let ts_lock = timesync.0.lock().unwrap();
+                ts_lock.clone()
+            };
+            let snaps: Vec<TimeSnapshot> = ts
+                .snapshots
+                .iter()
+                .cloned()
+                .filter(|s| s.real_time >= clip_start_real && s.real_time <= start_real)
+                .collect();
+            let evs: Vec<TimedEvent> = ts
+                .events
+                .iter()
+                .cloned()
+                .filter(|e| e.real_time >= clip_start_real && e.real_time <= start_real)
+                .collect();
+            write_clip_metadata(&db.0, &path, &snaps, &evs, clip_start_real).await.map(|_| ())
+        }
+        Err(e) => Err(e),
+    }
 }
 
 #[derive(Serialize)]
@@ -627,6 +657,7 @@ pub fn run() {
             let ffmpeg_process: SharedFfmpegProcess = Arc::new(AsyncMutex::new(ffmpeg_proc));
             let obs_ws_client: SharedObsWsClient = Arc::new(Mutex::new(None));
             let status_clone = status.clone();
+            let timesync_state = TimeSyncState(Arc::new(Mutex::new(TimeSyncData::default())));
             let settings_state = SettingsState(Arc::new(Mutex::new(settings_for_state)));
             let settings_state_clone2 = settings_state.clone();
             let settings_path_state = SettingsPath(config_path.clone());
@@ -637,6 +668,7 @@ pub fn run() {
             _app.manage(settings_state);
             _app.manage(settings_path_state);
             _app.manage(db_state.clone());
+            _app.manage(timesync_state.clone());
 
             let dir = settings.save_dir.clone();
             let obs_ws_client_clone2 = obs_ws_client.clone();
@@ -647,9 +679,10 @@ pub fn run() {
             let obs_ws_client_clone = obs_ws_client.clone();
             let ffmpeg_process_clone = ffmpeg_process.clone();
             let db_path_clone = db_state.clone();
+            let timesync_state_clone = timesync_state.clone();
 
             tauri::async_runtime::spawn(async move {
-                poll_lol_events(settings_state_clone2, move |all_data: &AllGameData, new_events: Vec<LolEvent>| {
+                poll_lol_events(settings_state_clone2, timesync_state_clone.clone(), move |all_data: &AllGameData, new_events: Vec<LolEvent>| {
                     let mut status = status_clone.lock().unwrap();
                     if status.game_state == GameState::NotStarted {
                         status.game_state = GameState::InProgress;
@@ -689,16 +722,27 @@ pub fn run() {
                                             tauri::async_runtime::spawn({
                                                 let db_path = db_path_clone.0.clone();
                                                 async move {
+                                                    let start_real = chrono::Utc::now().timestamp_millis() as f64 / 1000.0;
                                                     let mut proc = ffmpeg_clone.lock().await;
                                                     match proc.save().await {
                                                         Ok(path) => {
                                                             let dur = proc.segment_seconds * 10;
-                                                            let clip_start = event_clone.EventTime - dur as f64;
-                                                            let relevant_events: Vec<LolEvent> = events_snapshot
-                                                                .into_iter()
-                                                                .filter(|ev| ev.EventTime >= clip_start)
+                                                            let clip_start_real = start_real - dur as f64;
+                                                            let ts = {
+                                                                let ts_lock = timesync_state_clone.0.lock().unwrap();
+                                                                ts_lock.clone()
+                                                            };
+                                                            let snaps: Vec<TimeSnapshot> = ts.snapshots
+                                                                .iter()
+                                                                .cloned()
+                                                                .filter(|s| s.real_time >= clip_start_real && s.real_time <= start_real)
                                                                 .collect();
-                                                            if let Err(e) = write_clip_metadata(&db_path, &path, &relevant_events, clip_start).await {
+                                                            let evs: Vec<TimedEvent> = ts.events
+                                                                .iter()
+                                                                .cloned()
+                                                                .filter(|e| e.real_time >= clip_start_real && e.real_time <= start_real)
+                                                                .collect();
+                                                            if let Err(e) = write_clip_metadata(&db_path, &path, &snaps, &evs, clip_start_real).await {
                                                                 eprintln!("Failed to write metadata: {}", e);
                                                             }
                                                         }
@@ -723,6 +767,12 @@ pub fn run() {
                                 status.obs_state = ObsState::Recording;
                                 status.is_recording = true;
                                 status.replay_buffer_running = false;
+
+                                {
+                                    let mut ts = timesync_state_clone.0.lock().unwrap();
+                                    ts.snapshots.clear();
+                                    ts.events.clear();
+                                }
 
                                 match mode {
                                     RecordingMode::Obs => {
@@ -761,6 +811,12 @@ pub fn run() {
                                 status.obs_state = ObsState::NotRecording;
                                 status.is_recording = false;
                                 status.replay_buffer_running = false;
+
+                                {
+                                    let mut ts = timesync_state_clone.0.lock().unwrap();
+                                    ts.snapshots.clear();
+                                    ts.events.clear();
+                                }
                                 
                                 match mode {
                                     RecordingMode::Obs => {
@@ -807,7 +863,7 @@ pub fn run() {
         .expect("error while running tauri application");
 }
 
-async fn poll_lol_events<F>(settings: SettingsState, mut callback: F)
+async fn poll_lol_events<F>(settings: SettingsState, timesync: TimeSyncState, mut callback: F)
 where
     F: FnMut(&AllGameData, Vec<LolEvent>) + Send + 'static,
 {
@@ -836,12 +892,20 @@ where
                 if let Ok(body) = response.text().await {
                     match serde_json::from_str::<AllGameData>(&body) {
                         Ok(all_data) => {
+                            let now = chrono::Utc::now().timestamp_millis() as f64 / 1000.0;
                             let current_time = all_data.gameData.gameTime;
+                            {
+                                let mut ts = timesync.0.lock().unwrap();
+                                ts.snapshots.push(TimeSnapshot { game_time: current_time, real_time: now });
+                            }
 
                             for event in all_data.clone().events.events.into_iter() {
                                 if !seen_event_ids.contains(&event.EventID) {
                                     seen_event_ids.insert(event.EventID.clone());
                                     pending_events.push((event.clone(), event.EventTime.clone()));
+                                    let real = crate::timesync::game_to_real_time(event.EventTime, &timesync.0.lock().unwrap().snapshots)
+                                        .unwrap_or(now);
+                                    timesync.0.lock().unwrap().events.push(TimedEvent { event: event.clone(), real_time: real });
                                 }
                             }
 

--- a/src-tauri/src/timesync.rs
+++ b/src-tauri/src/timesync.rs
@@ -1,0 +1,88 @@
+use crate::lol::LolEvent;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeSnapshot {
+    pub game_time: f64,
+    pub real_time: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimedEvent {
+    #[serde(flatten)]
+    pub event: LolEvent,
+    pub real_time: f64,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct TimeSyncData {
+    pub snapshots: Vec<TimeSnapshot>,
+    pub events: Vec<TimedEvent>,
+}
+
+pub struct TimeSyncState(pub std::sync::Arc<std::sync::Mutex<TimeSyncData>>);
+
+pub fn game_to_real_time(game_time: f64, snaps: &[TimeSnapshot]) -> Option<f64> {
+    if snaps.is_empty() {
+        return None;
+    }
+    let mut prev = &snaps[0];
+    for snap in snaps.iter() {
+        if snap.game_time >= game_time {
+            if (snap.game_time - game_time).abs() < f64::EPSILON {
+                return Some(snap.real_time);
+            }
+            let dt = snap.game_time - prev.game_time;
+            if dt.abs() < f64::EPSILON {
+                return Some(prev.real_time);
+            }
+            let ratio = (game_time - prev.game_time) / dt;
+            return Some(prev.real_time + ratio * (snap.real_time - prev.real_time));
+        }
+        prev = snap;
+    }
+    // extrapolate using last two snapshots
+    if snaps.len() < 2 {
+        return Some(prev.real_time);
+    }
+    let last = snaps.last().unwrap();
+    let prev_last = &snaps[snaps.len() - 2];
+    let dt = last.game_time - prev_last.game_time;
+    if dt.abs() < f64::EPSILON {
+        Some(last.real_time)
+    } else {
+        Some(last.real_time + (game_time - last.game_time) / dt * (last.real_time - prev_last.real_time))
+    }
+}
+
+pub fn real_to_game_time(real_time: f64, snaps: &[TimeSnapshot]) -> Option<f64> {
+    if snaps.is_empty() {
+        return None;
+    }
+    let mut prev = &snaps[0];
+    for snap in snaps.iter() {
+        if snap.real_time >= real_time {
+            if (snap.real_time - real_time).abs() < f64::EPSILON {
+                return Some(snap.game_time);
+            }
+            let dt = snap.real_time - prev.real_time;
+            if dt.abs() < f64::EPSILON {
+                return Some(prev.game_time);
+            }
+            let ratio = (real_time - prev.real_time) / dt;
+            return Some(prev.game_time + ratio * (snap.game_time - prev.game_time));
+        }
+        prev = snap;
+    }
+    if snaps.len() < 2 {
+        return Some(prev.game_time);
+    }
+    let last = snaps.last().unwrap();
+    let prev_last = &snaps[snaps.len() - 2];
+    let dt = last.real_time - prev_last.real_time;
+    if dt.abs() < f64::EPSILON {
+        Some(last.game_time)
+    } else {
+        Some(last.game_time + (real_time - last.real_time) / dt * (last.game_time - prev_last.game_time))
+    }
+}

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -60,9 +60,12 @@ async function init() {
   let markers;
   let currentIndex = 0;
   let events = [];
+  let timeMap = [];
 
   try {
-    events = await invoke('get_clip_metadata', { path: file });
+    const meta = await invoke('get_clip_metadata', { path: file });
+    events = meta.events || [];
+    timeMap = meta.time_map || [];
   } catch (e) {
     console.error('Failed to load clip metadata', e);
   }


### PR DESCRIPTION
## Summary
- add `TimeSyncState` to capture snapshots of game time vs real time
- record snapshots and events in `poll_lol_events`
- store snapshots and events in clip metadata
- allow retrieving metadata with time mappings in `viewer.js`

## Testing
- `cargo check` *(fails: glib-2.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853aab52938832cb079f26260297e73