### PR TITLE
Implement concurrent ffmpeg record + replay

### DIFF
--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -304,3 +304,115 @@ pub async fn write_clip_metadata(
     // crate::db::write_clip_metadata(db_path, path, events, clip_start).await
     Ok(())
 }
+
+/// 単純な ffmpeg 録画を扱う構造体
+pub struct FfmpegRecorder {
+    pub child: Option<CommandChild>,
+    pub ffmpeg_path: PathBuf,
+    pub video_source: String,
+    pub audio_source: String,
+    pub fps: u32,
+    pub bitrate: String,
+    pub save_dir: PathBuf,
+    pub out_file: Option<PathBuf>,
+}
+
+impl FfmpegRecorder {
+    pub fn new(ffmpeg_path: PathBuf) -> Self {
+        Self {
+            child: None,
+            ffmpeg_path,
+            video_source: "1".into(),
+            audio_source: "none".into(),
+            fps: 30,
+            bitrate: "20M".into(),
+            save_dir: default_save_dir_path(),
+            out_file: None,
+        }
+    }
+
+    pub fn set_video_source(&mut self, src: String) {
+        self.video_source = src;
+    }
+
+    pub fn set_audio_source(&mut self, src: String) {
+        self.audio_source = src;
+    }
+
+    pub fn set_ffmpeg_path(&mut self, path: PathBuf) {
+        self.ffmpeg_path = path;
+    }
+
+    pub fn set_fps(&mut self, fps: u32) {
+        self.fps = fps;
+    }
+
+    pub fn set_bitrate(&mut self, bitrate: String) {
+        self.bitrate = bitrate;
+    }
+
+    pub fn set_save_dir(&mut self, dir: PathBuf) {
+        self.save_dir = dir;
+    }
+
+    /// ffmpeg をバックグラウンドで実行し録画を開始
+    pub async fn start(&mut self) -> Result<(), String> {
+        if let Some(child) = self.child.as_mut() {
+            if child.try_wait().map_err(|e| e.to_string())?.is_none() {
+                return Ok(());
+            }
+        }
+
+        if self.child.is_some() {
+            self.stop().await?;
+        }
+
+        let ts = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
+        let mut out = self.save_dir.clone();
+        fs::create_dir_all(&out).await.map_err(|e| e.to_string())?;
+        out.push(format!("record_{}.mp4", ts));
+
+        let gop = self.fps * 2;
+        let args = vec![
+            "-f", "avfoundation",
+            "-pixel_format", "nv12",
+            "-framerate", &(self.fps * 2).to_string(),
+            "-i", &format!("{}:{}", self.video_source, self.audio_source),
+            "-vf", &format!("fps={},format=yuv420p", self.fps),
+            "-c:v", "h264_videotoolbox",
+            "-realtime", "1",
+            "-bf", "0",
+            "-b:v", &self.bitrate,
+            "-g", &gop.to_string(),
+            "-keyint_min", &gop.to_string(),
+            "-sc_threshold", "0",
+            "-movflags", "+faststart",
+            &out.to_string_lossy(),
+        ];
+
+        let child = Command::new(&self.ffmpeg_path)
+            .args(&args)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+
+        self.child = Some(child);
+        self.out_file = Some(out);
+        Ok(())
+    }
+
+    /// 録画を停止し、出力ファイルのパスを返す
+    pub async fn stop(&mut self) -> Result<PathBuf, String> {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        match self.out_file.take() {
+            Some(p) => Ok(p),
+            None => Err("recording not started".into()),
+        }
+    }
+}
+
+/// 複数タスク間で FfmpegRecorder を共有する
+pub type SharedFfmpegRecorder = Arc<AsyncMutex<FfmpegRecorder>>;
+pub struct FfmpegRecorderState(pub SharedFfmpegRecorder);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,7 +18,10 @@ mod obs; // OBS WebSocket クライアント
 mod settings; // 設定関連 // SQLite アクセス
 
 use db::{cleanup_orphan_clips, get_clip_events, init_db, list_clips, DbPath};
-use ffmpeg::{write_clip_metadata, FfmpegProcess, FfmpegState, SharedFfmpegProcess};
+use ffmpeg::{
+    write_clip_metadata, FfmpegProcess, FfmpegState, SharedFfmpegProcess,
+    FfmpegRecorder, FfmpegRecorderState, SharedFfmpegRecorder,
+};
 use lol::{AllGameData, LolEvent};
 use obs::{send_obs_command_wrapper, set_record_directory, ObsWsState, SharedObsWsClient};
 use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState}; // DB 操作用
@@ -80,7 +83,7 @@ async fn set_recording_mode(
 async fn start_recording(
     state: tauri::State<'_, AppStatusState>,
     obs_state: tauri::State<'_, ObsWsState>,
-    ffmpeg_state: tauri::State<'_, FfmpegState>,
+    ffmpeg_state: tauri::State<'_, FfmpegRecorderState>,
 ) -> Result<(), String> {
     // ゲーム開始時に呼び出され、録画処理を開始する
     let mode = {
@@ -98,9 +101,8 @@ async fn start_recording(
         }
         RecordingMode::Shell => {
             // ffmpeg を用いた録画を開始
-            let shared = ffmpeg_state.0.clone();
-            let mut proc = shared.lock().await;
-            proc.start(shared.clone()).await
+            let mut rec = ffmpeg_state.0.lock().await;
+            rec.start().await
         }
     }
 }
@@ -109,7 +111,7 @@ async fn start_recording(
 async fn stop_recording(
     state: tauri::State<'_, AppStatusState>,
     obs_state: tauri::State<'_, ObsWsState>,
-    ffmpeg_state: tauri::State<'_, FfmpegState>,
+    ffmpeg_state: tauri::State<'_, FfmpegRecorderState>,
 ) -> Result<(), String> {
     // 録画を終了し状態をリセット
     let mode = {
@@ -126,8 +128,8 @@ async fn stop_recording(
             Ok(())
         }
         RecordingMode::Shell => {
-            let mut proc = ffmpeg_state.0.lock().await;
-            proc.stop().await
+            let mut rec = ffmpeg_state.0.lock().await;
+            rec.stop().await.map(|_| ())
         }
     }
 }
@@ -394,6 +396,40 @@ async fn save_ffmpeg_clip(state: tauri::State<'_, FfmpegState>) -> Result<(), St
     proc.save().await.map(|_| ())
 }
 
+#[tauri::command]
+async fn start_ffmpeg_record(
+    state: tauri::State<'_, FfmpegRecorderState>,
+    video_source: Option<String>,
+    audio_source: Option<String>,
+    fps: Option<u32>,
+    bitrate: Option<String>,
+) -> Result<(), String> {
+    let mut rec = state.0.lock().await;
+    if let Some(v) = video_source {
+        rec.set_video_source(v);
+    }
+    if let Some(a) = audio_source {
+        rec.set_audio_source(a);
+    }
+    if let Some(f) = fps {
+        rec.set_fps(f);
+    }
+    if let Some(b) = bitrate {
+        rec.set_bitrate(b);
+    }
+    rec.start().await
+}
+
+#[tauri::command]
+async fn stop_ffmpeg_record(
+    state: tauri::State<'_, FfmpegRecorderState>,
+) -> Result<String, String> {
+    let mut rec = state.0.lock().await;
+    rec.stop()
+        .await
+        .map(|p| p.to_string_lossy().to_string())
+}
+
 #[derive(Serialize)]
 struct DeviceInfo {
     index: i32,
@@ -589,6 +625,8 @@ pub fn run() {
             start_ffmpeg_replay,
             stop_ffmpeg_replay,
             save_ffmpeg_clip,
+            start_ffmpeg_record,
+            stop_ffmpeg_record,
             list_ffmpeg_devices,
             list_saved_videos,
             get_clip_metadata,
@@ -606,7 +644,7 @@ pub fn run() {
             let db_state = DbPath(db_path.clone());
             let mut ffmpeg_path = PathBuf::new();
             ffmpeg_path.push("ffmpeg");
-            let mut ffmpeg_proc = FfmpegProcess::new(ffmpeg_path);
+            let mut ffmpeg_proc = FfmpegProcess::new(ffmpeg_path.clone());
             ffmpeg_proc.set_segment_seconds(settings.segment_seconds);
             ffmpeg_proc.set_video_source(settings.video_source.clone());
             ffmpeg_proc.set_audio_source(settings.audio_source.clone());
@@ -614,6 +652,13 @@ pub fn run() {
             ffmpeg_proc.set_wrap_count(settings.wrap_count);
             ffmpeg_proc.set_bitrate(settings.bitrate.clone());
             ffmpeg_proc.set_save_dir(PathBuf::from(settings.save_dir.clone()));
+
+            let mut ffmpeg_rec = FfmpegRecorder::new(ffmpeg_path);
+            ffmpeg_rec.set_video_source(settings.video_source.clone());
+            ffmpeg_rec.set_audio_source(settings.audio_source.clone());
+            ffmpeg_rec.set_fps(settings.fps);
+            ffmpeg_rec.set_bitrate(settings.bitrate.clone());
+            ffmpeg_rec.set_save_dir(PathBuf::from(settings.save_dir.clone()));
 
             let status = AppStatus {
                 game_state: GameState::NotStarted,
@@ -625,6 +670,7 @@ pub fn run() {
             let status = Arc::new(Mutex::new(status));
 
             let ffmpeg_process: SharedFfmpegProcess = Arc::new(AsyncMutex::new(ffmpeg_proc));
+            let ffmpeg_recorder: SharedFfmpegRecorder = Arc::new(AsyncMutex::new(ffmpeg_rec));
             let obs_ws_client: SharedObsWsClient = Arc::new(Mutex::new(None));
             let status_clone = status.clone();
             let settings_state = SettingsState(Arc::new(Mutex::new(settings_for_state)));
@@ -634,6 +680,7 @@ pub fn run() {
             _app.manage(AppStatusState(status_clone.clone()));
             _app.manage(ObsWsState(obs_ws_client.clone()));
             _app.manage(FfmpegState(ffmpeg_process.clone()));
+            _app.manage(FfmpegRecorderState(ffmpeg_recorder.clone()));
             _app.manage(settings_state);
             _app.manage(settings_path_state);
             _app.manage(db_state.clone());
@@ -646,6 +693,7 @@ pub fn run() {
 
             let obs_ws_client_clone = obs_ws_client.clone();
             let ffmpeg_process_clone = ffmpeg_process.clone();
+            let ffmpeg_recorder_clone = ffmpeg_recorder.clone();
             let db_path_clone = db_state.clone();
 
             tauri::async_runtime::spawn(async move {
@@ -722,7 +770,7 @@ pub fn run() {
                                 status.game_state = GameState::InProgress;
                                 status.obs_state = ObsState::Recording;
                                 status.is_recording = true;
-                                status.replay_buffer_running = false;
+                                status.replay_buffer_running = true;
 
                                 match mode {
                                     RecordingMode::Obs => {
@@ -736,15 +784,23 @@ pub fn run() {
                                         });
                                     }
                                     RecordingMode::Shell => {
-                                        let ffmpeg_clone = ffmpeg_process_clone.clone();
+                                        let ffmpeg_proc_clone = ffmpeg_process_clone.clone();
+                                        let ffmpeg_rec_clone = ffmpeg_recorder_clone.clone();
                                         tauri::async_runtime::spawn({
-                                            let ffmpeg_process_clone = ffmpeg_process_clone.clone();
+                                            let proc = ffmpeg_process_clone.clone();
                                             async move {
-                                                if let Err(e) = ffmpeg_clone.lock().await.start(ffmpeg_process_clone).await {
-                                                    eprintln!("Failed to start ffmpeg recording: {}", e);
+                                                if let Err(e) = ffmpeg_proc_clone.lock().await.start(proc).await {
+                                                    eprintln!("Failed to start ffmpeg replay buffer: {}", e);
                                                 } else {
-                                                    println!("Started ffmpeg recording");
+                                                    println!("Started ffmpeg replay buffer");
                                                 }
+                                            }
+                                        });
+                                        tauri::async_runtime::spawn(async move {
+                                            if let Err(e) = ffmpeg_rec_clone.lock().await.start().await {
+                                                eprintln!("Failed to start ffmpeg recording: {}", e);
+                                            } else {
+                                                println!("Started ffmpeg recording");
                                             }
                                         });
                                     }
@@ -774,9 +830,17 @@ pub fn run() {
                                         });
                                     }
                                     RecordingMode::Shell => {
-                                        let ffmpeg_clone = ffmpeg_process_clone.clone();
+                                        let ffmpeg_proc_clone = ffmpeg_process_clone.clone();
+                                        let ffmpeg_rec_clone = ffmpeg_recorder_clone.clone();
                                         tauri::async_runtime::spawn(async move {
-                                            if let Err(e) = ffmpeg_clone.lock().await.stop().await {
+                                            if let Err(e) = ffmpeg_proc_clone.lock().await.stop().await {
+                                                eprintln!("Failed to stop ffmpeg replay buffer: {}", e);
+                                            } else {
+                                                println!("Stopped ffmpeg replay buffer");
+                                            }
+                                        });
+                                        tauri::async_runtime::spawn(async move {
+                                            if let Err(e) = ffmpeg_rec_clone.lock().await.stop().await {
                                                 eprintln!("Failed to stop ffmpeg recording: {}", e);
                                             } else {
                                                 println!("Stopped ffmpeg recording");


### PR DESCRIPTION
## Summary
- run the ffmpeg replay buffer and the normal recorder together when LoL matches start
- stop both recordings when the game ends

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e8b0b840832cb25f5d9bf8086054