### PR TITLE
Simplify OBS control view

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -39,7 +39,7 @@
 
 ## 5. 画面構成
 - `index.html` : ホーム画面。モード選択リンクのみ【F:src/index.html†L1-L27】。
-- `obs.html` : OBS 録画向け操作画面【F:src/obs.html†L13-L60】。
+- `obs.html` : OBS 録画向け操作画面【F:src/obs.html†L13-L53】。
 - `videos.html` : 保存済み動画一覧を表示【F:src/videos.html†L1-L35】。
 - `video.html` : 動画再生とイベント表示【F:src/video.html†L1-L32】。
 

--- a/src/obs.html
+++ b/src/obs.html
@@ -10,7 +10,7 @@
     <script type="module" src="/debug.js" defer></script>
   </head>
 
-    <body class="h-screen flex flex-col overscroll-none">
+  <body class="h-screen flex flex-col overscroll-none">
     <nav class="bg-gray-800 text-gray-100 py-2 fixed top-0 left-0 w-full z-10 overscroll-none">
       <div class="container mx-auto flex items-center gap-4">
         <a class="font-bold text-white" href="index.html">Clip Tool</a>
@@ -21,63 +21,30 @@
       </div>
     </nav>
     <main class="container py-4 app-container overscroll-none">
-      <h1 class="mb-4 text-center">LoL イベントトリガー録画アプリ</h1>
+      <h1 class="mb-4 text-center">OBS 操作</h1>
 
-      <div class="flex flex-col md:flex-row w-full h-full gap-6">
-        <div class="md:w-1/2 order-2 md:order-1 flex flex-col">
-          <div class="log-container">
-            <h2 class="h5 mb-3">📜 ゲームイベントログ</h2>
-            <ul id="eventLog" class="list-unstyled"></ul>
-          </div>
+      <div class="flex flex-col w-full gap-6">
+        <div class="status-panel mb-3">
+          <div><strong>OBS状態:</strong> <span id="obsState"></span></div>
         </div>
 
-        <div class="md:w-1/2 order-1 md:order-2 flex flex-col">
-          <div class="status-panel mb-3">
-            <div><strong>ゲーム状態:</strong> <span id="gameState"></span></div>
-            <div><strong>OBS状態:</strong> <span id="obsState"></span></div>
-            <div class="form-check form-switch mode-toggle" style="display:none;">
-              <input class="form-check-input" type="checkbox" id="modeToggle" />
-              <label class="form-check-label" for="modeToggle">シェル録画を使用</label>
-            </div>
-          </div>
+        <div class="button-group mb-4">
+          <h2 class="h5 mb-3">🎥 録画操作</h2>
+          <button class="px-4 py-2 mr-2 border border-blue-600 text-blue-600 rounded" id="btnStart">録画開始</button>
+          <button class="px-4 py-2 border border-gray-600 text-gray-600 rounded" id="btnStop">録画停止</button>
+        </div>
 
-          <div class="button-group mb-4">
-            <h2 class="h5 mb-3">🎥 録画操作</h2>
-            <button class="px-4 py-2 mr-2 border border-blue-600 text-blue-600 rounded" id="btnStart">録画開始</button>
-            <button class="px-4 py-2 border border-gray-600 text-gray-600 rounded" id="btnStop">録画停止</button>
-          </div>
-
-          <div class="button-group mb-4">
-            <h2 class="h5 mb-3">🔁 リプレイバッファ</h2>
-            <button class="px-4 py-2 mr-2 border border-green-600 text-green-600 rounded" id="btnReplayStart">開始</button>
-            <button class="px-4 py-2 mr-2 border border-yellow-500 text-yellow-500 rounded" id="btnReplayStop">停止</button>
-            <button class="px-4 py-2 border border-teal-500 text-teal-500 rounded" id="btnReplaySave">保存</button>
-          </div>
-
-          <div class="button-group mb-4">
-            <h2 class="h5 mb-3">🛠 ユーティリティ</h2>
-            <div class="flex mb-2 space-x-2">
-              <input class="border border-gray-600 bg-gray-800 text-gray-100 rounded p-1 flex-grow" id="saveDirInput" />
-              <button class="px-2 py-1 border border-gray-500 text-gray-700 rounded" id="chooseDirBtn">選択</button>
-            </div>
-            <div class="flex mb-2 space-x-2">
-              <label class="block text-sm" for="eventDelayInput">イベント遅延(s)</label>
-              <input class="border border-gray-600 bg-gray-800 text-gray-100 rounded p-1" id="eventDelayInput" value="3" />
-            </div>
-            <button class="px-2 py-1 border border-blue-600 text-blue-600 rounded" id="btnGetDir">保存先を開く</button>
-            <button class="px-2 py-1 ml-2 border border-green-600 text-green-600 rounded" id="btnSaveSettings">設定保存</button>
-          </div>
+        <div class="button-group mb-4">
+          <h2 class="h5 mb-3">🔁 リプレイバッファ</h2>
+          <button class="px-4 py-2 mr-2 border border-green-600 text-green-600 rounded" id="btnReplayStart">開始</button>
+          <button class="px-4 py-2 mr-2 border border-yellow-500 text-yellow-500 rounded" id="btnReplayStop">停止</button>
+          <button class="px-4 py-2 border border-teal-500 text-teal-500 rounded" id="btnReplaySave">保存</button>
         </div>
       </div>
     </main>
 
     <script>
       window.addEventListener("DOMContentLoaded", () => {
-        const t = document.getElementById("modeToggle");
-        if (t) {
-          t.checked = false;
-          t.disabled = true;
-        }
         // ページ遷移時にアプリの録画モードも OBS に更新する
         window.__TAURI__.core.invoke("set_recording_mode", { mode: "Obs" });
       });

--- a/src/settings.js
+++ b/src/settings.js
@@ -139,8 +139,10 @@ window.addEventListener("DOMContentLoaded", async () => {
 // 画面上の状態表示を最新に更新する
 async function updateStatus() {
   const status = await invoke('get_status');
-  document.getElementById('gameState').textContent = status.game_state;
-  document.getElementById('obsState').textContent = status.obs_state;
+  const game = document.getElementById('gameState');
+  if (game) game.textContent = status.game_state;
+  const obs = document.getElementById('obsState');
+  if (obs) obs.textContent = status.obs_state;
   const toggle = document.getElementById('modeToggle');
   if (toggle) {
     toggle.checked = status.recording_mode === 'Shell';
@@ -166,9 +168,13 @@ async function updateStatus() {
 // 画面のログ欄へテキストを追加
 function logEvent(message) {
   const log = document.getElementById('eventLog');
-  const entry = document.createElement('li');
-  entry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
-  log.prepend(entry);
+  if (log) {
+    const entry = document.createElement('li');
+    entry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
+    log.prepend(entry);
+  } else {
+    console.log(message);
+  }
 }
 
 // 設定ファイルを読み込んでフォームに反映


### PR DESCRIPTION
## Summary
- trim obs.html to only show OBS controls and status
- guard missing elements in updateStatus and logEvent
- update design docs for new obs.html line numbers

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `gobject-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a4c5a278832cad966e494d5ec2ff