### PR TITLE
Refactor scripts and backend

### DIFF
--- a/ffmpeg_replaybuffer.sh
+++ b/ffmpeg_replaybuffer.sh
@@ -2,16 +2,16 @@
 # ffmpeg を使った簡易リプレイバッファ録画スクリプト
 set -Eeuo pipefail
 
-# ffmpeg コマンドのパス。環境変数で上書き可能
-FFMPEG_BIN=${FFMPEG_BIN:-ffmpeg}
-# デフォルト設定値を各変数に格納
-FPS=30 BITRATE=20M SRC="1:none" SEG_S=6 WRAP=11 RAM_MB=512 OUT_DIR="$HOME/Movies"
+# ffmpeg コマンドのパス (必要に応じて環境変数で指定)
+FFMPEG_CMD=${FFMPEG_BIN:-ffmpeg}
+# 各種デフォルト設定
+FPS=30 VIDEO_BITRATE=20M SRC="1:none" SEG_SECONDS=6 WRAP=11 RAM_MB=512 OUT_DIR="$HOME/Movies"
 
 # コマンドライン引数の解析
 while getopts "f:b:s:t:n:r:o:h" o; do
   case $o in
-    f) FPS=$OPTARG ;; b) BITRATE=$OPTARG ;;
-    s) SRC=$OPTARG ;; t) SEG_S=$OPTARG ;;
+    f) FPS=$OPTARG ;; b) VIDEO_BITRATE=$OPTARG ;;
+    s) SRC=$OPTARG ;; t) SEG_SECONDS=$OPTARG ;;
     n) WRAP=$OPTARG ;; r) RAM_MB=$OPTARG ;;
     o) OUT_DIR=$OPTARG ;;
     h|*) echo "usage: $0 [-f fps] [-b bitrate] [-s src] [-t seg_sec] [-n wrap] [-r ram_mb] [-o out_dir]"; exit 0;;
@@ -19,7 +19,7 @@ while getopts "f:b:s:t:n:r:o:h" o; do
 done
 
 # GOP 長やバッファ長などの内部パラメータを計算
-GOP=$((FPS*SEG_S)) OFFSET=$((-(WRAP-1))) DUR=$((SEG_S*(WRAP-1)))
+GOP=$((FPS*SEG_SECONDS)) OFFSET=$((-(WRAP-1))) DUR=$((SEG_SECONDS*(WRAP-1)))
 BLOCKS=$((RAM_MB*2048))
 # RAM ディスクを作成して一時録画用ディレクトリを用意
 DEV=$(hdiutil attach -nomount "ram://$BLOCKS" | tr -d '[:space:]')
@@ -41,12 +41,12 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # ffmpeg をバックグラウンド実行し循環バッファを構築
-"$FFMPEG_BIN" -f avfoundation -pixel_format nv12 -framerate $((FPS*2)) -i "$SRC" \
+"$FFMPEG_CMD" -f avfoundation -pixel_format nv12 -framerate $((FPS*2)) -i "$SRC" \
   -vf "fps=$FPS,format=yuv420p" \
-  -c:v h264_videotoolbox -realtime 1 -bf 0 -b:v "$BITRATE" \
+  -c:v h264_videotoolbox -realtime 1 -bf 0 -b:v "$VIDEO_BITRATE" \
   -g "$GOP" -keyint_min "$GOP" -sc_threshold 0 \
-  -force_key_frames "expr:gte(t,n_forced*${SEG_S}-0.1)" -an \
-  -f segment -segment_time "$SEG_S" -segment_format ts \
+  -force_key_frames "expr:gte(t,n_forced*${SEG_SECONDS}-0.1)" -an \
+  -f segment -segment_time "$SEG_SECONDS" -segment_format ts \
   -segment_wrap "$WRAP" -segment_list "$DIR/list.m3u8" \
   -segment_list_size "$WRAP" -segment_list_type m3u8 \
   -segment_list_flags +live "$DIR/seg%03d.ts" & FF_PID=$!

--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -21,10 +21,15 @@ fn default_save_dir_path() -> PathBuf {
 
 /// ffmpeg コマンド実行の状態を保持
 /// RAM ディスクやバッファ設定もここで管理する
+/// ffmpeg プロセスとそのパラメータを保持する構造体
 pub struct FfmpegProcess {
-    pub child: Option<CommandChild>,
-    pub ram_device: Option<String>,
-    pub ram_dir: Option<PathBuf>,
+    /// 実行中の ffmpeg プロセス
+    pub process: Option<CommandChild>,
+    /// RAM ディスクのデバイス名 (macOS のみ)
+    pub ram_device_id: Option<String>,
+    /// 一時セグメントを保存しているディレクトリ
+    pub buffer_dir: Option<PathBuf>,
+    /// 利用する ffmpeg バイナリへのパス
     pub ffmpeg_path: PathBuf,
     pub segment_seconds: u32,
     pub video_source: String,
@@ -40,9 +45,9 @@ impl FfmpegProcess {
     pub fn new(ffmpeg_path: PathBuf) -> Self {
         // デフォルト値を設定して初期化
         Self {
-            child: None,
-            ram_device: None,
-            ram_dir: None,
+            process: None,
+            ram_device_id: None,
+            buffer_dir: None,
             ffmpeg_path,
             segment_seconds: 6,
             video_source: "1".into(),
@@ -100,15 +105,15 @@ impl FfmpegProcess {
     pub async fn start(&mut self, shared: SharedFfmpegProcess) -> Result<(), String> {
         // ffmpeg プロセスを起動し循環バッファを構築
         // 既に動いている場合は何もしない
-        if let Some(child) = self.child.as_mut() {
-            if child.try_wait().map_err(|e| e.to_string())?.is_none() {
+        if let Some(process) = self.process.as_mut() {
+            if process.try_wait().map_err(|e| e.to_string())?.is_none() {
                 println!("ffmpeg process already running");
                 return Ok(());
             }
             println!("ffmpeg process was stopped, restarting");
         }
 
-        if self.child.is_some() {
+        if self.process.is_some() {
             self.stop().await?;
         }
         const WRAP: u32 = 11;
@@ -178,10 +183,11 @@ impl FfmpegProcess {
             .spawn() // ffmpeg プロセス開始
             .map_err(|e| e.to_string())?;
 
-        self.child = Some(child);
-        // プロセスハンドルを保存しておく
+        // プロセスハンドルを保存
+        self.process = Some(child);
 
-        self.ram_dir = Some(dir.clone());
+        // 一時セグメント保存用ディレクトリを記録
+        self.buffer_dir = Some(dir.clone());
         // 一時保存用ディレクトリのパス
 
         let save_path = dir.join(".trigger_save");
@@ -196,7 +202,7 @@ impl FfmpegProcess {
                 }
                 {
                     let p = shared.lock().await;
-                    if p.child.is_none() {
+                    if p.process.is_none() {
                         break;
                     }
                 }
@@ -224,24 +230,24 @@ impl FfmpegProcess {
 
     pub async fn stop(&mut self) -> Result<(), String> {
         // ffmpeg プロセスと一時ディレクトリを後始末
-        if let Some(mut child) = self.child.take() {
+        if let Some(mut child) = self.process.take() {
             println!("Stopping ffmpeg process");
             let _ = child.kill(); // プロセス終了を試みる
             let _ = child.wait(); // ゾンビ化を防ぐために待機
         }
-        if let Some(dir) = &self.ram_dir {
+        if let Some(dir) = &self.buffer_dir {
             // 作成した一時ディレクトリを削除
             let _ = fs::remove_dir_all(dir).await;
         }
-        self.ram_device = None;
-        self.ram_dir = None;
+        self.ram_device_id = None;
+        self.buffer_dir = None;
         Ok(())
     }
 
     pub async fn save(&mut self) -> Result<PathBuf, String> {
         // 現在のバッファ内容を mp4 として保存
 
-        let dir = if let Some(d) = &self.ram_dir {
+        let dir = if let Some(d) = &self.buffer_dir {
             d.clone()
         } else {
             return Err("ffmpeg not running".into());

--- a/src/settings.js
+++ b/src/settings.js
@@ -4,7 +4,8 @@ const { open } = window.__TAURI__.dialog;
 // Tauri API の基本機能を利用
 
 // input 要素から整数値を取得し、最小値チェックを行うユーティリティ
-function getInt(id, min = 1) {
+// 数値入力を整数として取得し、最小値を満たしているか検証
+function parseIntInput(id, min = 1) {
   const el = document.getElementById(id);
   if (!el) return NaN;
   const val = parseInt(el.value, 10);
@@ -14,7 +15,8 @@ function getInt(id, min = 1) {
   return val; // チェックを通過した値を返す
 }
 
-function getFloat(id, min = 0) {
+// 数値入力を浮動小数点として取得し、最小値をチェック
+function parseFloatInput(id, min = 0) {
   const el = document.getElementById(id);
   if (!el) return NaN;
   const val = parseFloat(el.value);
@@ -34,7 +36,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   document.getElementById('modeToggle')?.addEventListener('change', async (e) => {
     const mode = e.target.checked ? 'Shell' : 'Obs';
     await invoke('set_recording_mode', { mode });
-    updateStatus();
+    refreshStatus();
   });
   document.getElementById('btnStart')?.addEventListener('click', async () => {
     try {
@@ -43,7 +45,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     } catch (e) {
       logEvent(`⚠️ 録画開始に失敗しました: ${e}`);
     }
-    updateStatus();
+    refreshStatus();
   });
 
   document.getElementById('btnStop')?.addEventListener('click', async () => {
@@ -53,18 +55,18 @@ window.addEventListener("DOMContentLoaded", async () => {
     } catch (e) {
       logEvent(`⚠️ 録画停止に失敗しました: ${e}`);
     }
-    updateStatus();
+    refreshStatus();
   });
 
   document.getElementById('btnReplayStart')?.addEventListener('click', async () => {
     const isShell = document.getElementById('modeToggle').checked;
     if (isShell) {
       try {
-        const segmentSeconds = getInt('segmentSeconds');
-        const fps = getInt('fpsInput');
+        const segmentSeconds = parseIntInput('segmentSeconds');
+        const fps = parseIntInput('fpsInput');
         const videoSource = document.getElementById('videoSourceInput').value;
         const audioSource = document.getElementById('audioSourceInput').value;
-        const wrapCount = getInt('wrapCountInput');
+        const wrapCount = parseIntInput('wrapCountInput');
         const bitrate = document.getElementById('bitrateInput').value;
         await invoke('start_ffmpeg_replay', { segmentSeconds, fps, videoSource, audioSource, wrapCount, bitrate });
         logEvent("🔁 リプレイバッファを開始しました");
@@ -81,7 +83,7 @@ window.addEventListener("DOMContentLoaded", async () => {
         logEvent(`⚠️ リプレイバッファの開始に失敗しました: ${e}`);
       }
     }
-    updateStatus();
+    refreshStatus();
   });
 
   document.getElementById('btnReplayStop')?.addEventListener('click', async () => {
@@ -96,7 +98,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     } catch (e) {
       logEvent(`⚠️ リプレイバッファの停止に失敗しました: ${e}`);
     }
-    updateStatus();
+    refreshStatus();
   });
 
   document.getElementById('btnReplaySave')?.addEventListener('click', async () => {
@@ -111,7 +113,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     } catch (e) {
       logEvent(`⚠️ リプレイバッファの保存に失敗しました: ${e}`);
     }
-    updateStatus();
+    refreshStatus();
   });
 
   document.getElementById('chooseDirBtn')?.addEventListener('click', async () => {
@@ -132,12 +134,13 @@ window.addEventListener("DOMContentLoaded", async () => {
     await saveSettings();
   });
 
-  setInterval(updateStatus, 1500);
-  updateStatus();
+  setInterval(refreshStatus, 1500);
+  refreshStatus();
 });
 
 // 画面上の状態表示を最新に更新する
-async function updateStatus() {
+// 現在の状態を取得して画面へ反映
+async function refreshStatus() {
   const status = await invoke('get_status');
   const game = document.getElementById('gameState');
   if (game) game.textContent = status.game_state;
@@ -152,7 +155,6 @@ async function updateStatus() {
   if (saveBtn) {
     saveBtn.disabled = !status.replay_buffer_running;
   }
- // updateStatus end
   const dbg = document.getElementById('debugStatus');
   if (dbg) {
     const modeText = status.recording_mode === 'Shell' ? 'ffmpeg' : 'OBS';
@@ -233,11 +235,11 @@ async function saveSettings() {
   const base = await invoke('load_settings_cmd');
   const settings = { ...base };
   try {
-    settings.segment_seconds = getInt('segmentSeconds');
-    settings.fps = getInt('fpsInput');
-    const wrap = getInt('wrapCountInput');
+    settings.segment_seconds = parseIntInput('segmentSeconds');
+    settings.fps = parseIntInput('fpsInput');
+    const wrap = parseIntInput('wrapCountInput');
     settings.wrap_count = wrap;
-    settings.event_trigger_delay = getFloat('eventDelayInput', 0);
+    settings.event_trigger_delay = parseFloatInput('eventDelayInput', 0);
   } catch (e) {
     alert(e.message);
     return;


### PR DESCRIPTION
## Summary
- clean up ffmpeg replay script variable names
- rename process fields in Rust backend
- clarify helper names in settings.js

## Testing
- `node -c src/settings.js`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `glib-2.0.pc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a6342c98832c81f0c6c91d9d7995