### PR TITLE
Add flexi_logger for unified logging

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1005,6 +1005,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "flexi_logger"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469e584c031833564840fb0cdbce99bdfe946fd45480a188545e73a76f45461c"
+dependencies = [
+ "chrono",
+ "glob",
+ "is-terminal",
+ "lazy_static",
+ "log",
+ "nu-ansi-term",
+ "regex",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1878,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,7 +2101,9 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dirs",
+ "flexi_logger",
  "futures-util",
+ "log",
  "reqwest",
  "serde",
  "serde_json",
@@ -2273,6 +2302,15 @@ dependencies = [
  "serde",
  "tauri-winrt-notification",
  "zbus",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5248,6 +5286,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5277,6 +5324,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5321,6 +5383,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5333,6 +5401,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5342,6 +5416,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5363,6 +5443,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5372,6 +5458,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5387,6 +5479,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5396,6 +5494,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,4 +31,6 @@ dirs = "6.0.0"
 tauri-plugin-fs = "2.3.0"
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
+log = "0.4"
+flexi_logger = "0.27"
 

--- a/src-tauri/src/ffmpeg.rs
+++ b/src-tauri/src/ffmpeg.rs
@@ -11,6 +11,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::lol::LolEvent;
 use tokio::fs;
+use log::info;
 
 fn default_save_dir_path() -> PathBuf {
     // ホームディレクトリ直下の Movies フォルダを利用
@@ -96,7 +97,7 @@ impl FfmpegProcess {
     }
 
     pub fn set_save_dir(&mut self, dir: PathBuf) {
-        println!("Set save directory to {:?}", dir);
+        info!("Set save directory to {:?}", dir);
         // クリップ保存先ディレクトリ
         self.save_dir = dir;
     }
@@ -107,10 +108,10 @@ impl FfmpegProcess {
         // 既に動いている場合は何もしない
         if let Some(process) = self.process.as_mut() {
             if process.try_wait().map_err(|e| e.to_string())?.is_none() {
-                println!("ffmpeg process already running");
+                info!("ffmpeg process already running");
                 return Ok(());
             }
-            println!("ffmpeg process was stopped, restarting");
+            info!("ffmpeg process was stopped, restarting");
         }
 
         if self.process.is_some() {
@@ -121,9 +122,13 @@ impl FfmpegProcess {
 
         // セグメント保存用ディレクトリを作成
         let dir = PathBuf::from("/tmp/lol_obs_clip/replay");
-        println!(
+        info!(
             "Creating segment directory {:?} (segment_seconds={}, wrap_count={}, fps={}, bitrate={})",
-            dir, self.segment_seconds, self.wrap_count, self.fps, self.bitrate
+            dir,
+            self.segment_seconds,
+            self.wrap_count,
+            self.fps,
+            self.bitrate
         );
         if dir.exists() {
             fs::remove_dir_all(&dir).await.map_err(|e| e.to_string())?;
@@ -177,7 +182,7 @@ impl FfmpegProcess {
         args.push("-segment_list_flags".into());
         args.push("+live".into());
         args.push(dir.join("seg%03d.ts").to_string_lossy().into_owned());
-        println!("Running ffmpeg command: {:?} {:?}", self.ffmpeg_path, args);
+        info!("Running ffmpeg command: {:?} {:?}", self.ffmpeg_path, args);
         let child = Command::new(&self.ffmpeg_path)
             .args(&args)
             .spawn() // ffmpeg プロセス開始
@@ -208,14 +213,14 @@ impl FfmpegProcess {
                 }
                 if fs::metadata(&save_path).await.is_ok() {
                     // .trigger_save を検知したらバッファを保存
-                    println!("Save trigger detected, saving current buffer");
+                    info!("Save trigger detected, saving current buffer");
                     let _ = fs::remove_file(&save_path).await;
                     let mut p = shared.lock().await;
                     let _ = p.save().await;
                 }
                 if fs::metadata(&quit_path).await.is_ok() {
                     // .trigger_quit を検知したらプロセスを終了
-                    println!("Quit trigger detected, stopping ffmpeg process");
+                    info!("Quit trigger detected, stopping ffmpeg process");
                     let _ = fs::remove_file(&quit_path).await;
                     let mut p = shared.lock().await;
                     let _ = p.stop().await;
@@ -231,7 +236,7 @@ impl FfmpegProcess {
     pub async fn stop(&mut self) -> Result<(), String> {
         // ffmpeg プロセスと一時ディレクトリを後始末
         if let Some(mut child) = self.process.take() {
-            println!("Stopping ffmpeg process");
+            info!("Stopping ffmpeg process");
             let _ = child.kill(); // プロセス終了を試みる
             let _ = child.wait(); // ゾンビ化を防ぐために待機
         }
@@ -261,9 +266,11 @@ impl FfmpegProcess {
         out.push(format!("replay_{}.mp4", ts)); // 保存先ファイル名を決定
 
         // ffmpeg を呼び出してクリップを出力
-        println!(
+        info!(
             "Saving replay buffer to {:?} (offset={}, duration={})",
-            out, offset, dur
+            out,
+            offset,
+            dur
         );
         let output = Command::new(&self.ffmpeg_path)
             .args([
@@ -288,7 +295,7 @@ impl FfmpegProcess {
             return Err(String::from_utf8_lossy(&output.stderr).to_string());
         }
 
-        println!("Saved clip to {:?}", out);
+        info!("Saved clip to {:?}", out);
         // 正常終了した場合は保存先パスを返す
 
         Ok(out)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,8 @@ use tauri::{async_runtime::spawn, Manager};
 use tokio::process::Command;
 use tokio::sync::Mutex as AsyncMutex;
 use tauri_plugin_notification::NotificationExt;
+use flexi_logger::{Duplicate, FileSpec, Logger};
+use log::{error, info};
 
 mod db;
 mod ffmpeg; // ffmpeg 管理
@@ -22,6 +24,19 @@ use ffmpeg::{write_clip_metadata, FfmpegProcess, FfmpegState, SharedFfmpegProces
 use lol::{AllGameData, LolEvent};
 use obs::{send_obs_command_wrapper, set_record_directory, ObsWsState, SharedObsWsClient};
 use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState}; // DB 操作用
+
+fn init_logging() {
+    let mut dir = dirs::data_local_dir().unwrap_or_else(|| PathBuf::from("."));
+    dir.push("lol_clip_tool");
+    std::fs::create_dir_all(&dir).ok();
+    Logger::try_with_env_or_str("info")
+        .unwrap()
+        .log_to_file(FileSpec::default().directory(dir))
+        .duplicate_to_stdout(Duplicate::All)
+        .format(flexi_logger::detailed_format)
+        .start()
+        .unwrap();
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 enum GameState {
@@ -72,7 +87,7 @@ async fn set_recording_mode(
     let mut lock = state.0.lock().unwrap();
     lock.recording_mode = mode;
 
-    println!("Recording mode set to: {:?}", lock.recording_mode);
+    info!("Recording mode set to: {:?}", lock.recording_mode);
     Ok(())
 }
 
@@ -343,8 +358,15 @@ async fn start_ffmpeg_replay(
     wrap_count: Option<u32>,
     bitrate: Option<String>,
 ) -> Result<(), String> {
-    println!("Starting ffmpeg replay buffer with segment_seconds: {:?}, video_source: {:?}, audio_source: {:?}, fps: {:?}, wrap_count: {:?}, bitrate: {:?}", 
-        segment_seconds, video_source, audio_source, fps, wrap_count, bitrate);
+    info!(
+        "Starting ffmpeg replay buffer with segment_seconds: {:?}, video_source: {:?}, audio_source: {:?}, fps: {:?}, wrap_count: {:?}, bitrate: {:?}",
+        segment_seconds,
+        video_source,
+        audio_source,
+        fps,
+        wrap_count,
+        bitrate
+    );
 
     let mut proc = state.0.lock().await;
     {
@@ -571,6 +593,7 @@ struct AppStatusState(Arc<Mutex<AppStatus>>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    init_logging();
     tauri::Builder::default()
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
@@ -660,27 +683,46 @@ pub fn run() {
                     for event in new_events {
                         match event.EventName.as_str() {
                             "ChampionKill" => {
-                                println!("{} champion killed: {} by {}", event.EventTime, event.VictimName.as_deref().unwrap_or("Unknown"), event.KillerName.as_deref().unwrap_or("Unknown"));
+                                info!(
+                                    "{} champion killed: {} by {}",
+                                    event.EventTime,
+                                    event.VictimName.as_deref().unwrap_or("Unknown"),
+                                    event.KillerName.as_deref().unwrap_or("Unknown")
+                                );
                             }
                             "Multikill" => {
                                 if let Some(killer_name) = &event.KillerName {
                                     // アクティブプレイヤーの名前がキルしたプレイヤー名に含まれているか確認：うまく取れていない
                                     if !killer_name.contains(all_data.activePlayer.riotIdGameName.as_str()) {
-                                        println!("Killer name does not match active player: {} != {}", killer_name, all_data.activePlayer.riotIdGameName);
+                                        info!(
+                                            "Killer name does not match active player: {} != {}",
+                                            killer_name,
+                                            all_data.activePlayer.riotIdGameName
+                                        );
                                         continue;
                                     }
 
-                                    println!("{} multikill by {}: {}, active_player: {}", event.EventTime, killer_name, event.EventName, all_data.activePlayer.summonerName);
-                                    println!("Game Time: {}, Event Time:{}", all_data.gameData.gameTime, event.EventTime);
+                                    info!(
+                                        "{} multikill by {}: {}, active_player: {}",
+                                        event.EventTime,
+                                        killer_name,
+                                        event.EventName,
+                                        all_data.activePlayer.summonerName
+                                    );
+                                    info!(
+                                        "Game Time: {}, Event Time:{}",
+                                        all_data.gameData.gameTime,
+                                        event.EventTime
+                                    );
 
                                     match mode {
                                         RecordingMode::Obs => {
                                             let obs_client_clone = obs_ws_client_clone.clone();
                                             tauri::async_runtime::spawn(async move {
                                                 if let Err(e) = send_obs_command_wrapper(obs_client_clone, "SaveReplayBuffer").await {
-                                                    eprintln!("Failed to send Multikill command to OBS: {}", e);
+                                                    error!("Failed to send Multikill command to OBS: {}", e);
                                                 } else {
-                                                    println!("Sent Multikill command to OBS");
+                                                    info!("Sent Multikill command to OBS");
                                                 }
                                             });
                                         }
@@ -701,11 +743,11 @@ pub fn run() {
                                                                 .filter(|ev| ev.EventTime >= clip_start)
                                                                 .collect();
                                                             if let Err(e) = write_clip_metadata(&db_path, &path, &relevant_events, clip_start).await {
-                                                                eprintln!("Failed to write metadata: {}", e);
+                                                                error!("Failed to write metadata: {}", e);
                                                             }
                                                         }
                                                         Err(e) => {
-                                                            eprintln!("Failed to save clip: {}", e);
+                                                            error!("Failed to save clip: {}", e);
                                                         }
                                                     }
                                                 }
@@ -717,7 +759,7 @@ pub fn run() {
                             
                             // ゲームスタート時にOBSかffmpegの録画を開始
                             "GameStart" => {
-                                println!("Game started at {}", event.EventTime);
+                                info!("Game started at {}", event.EventTime);
 
                                 // ゲーム状態を更新
                                 let mut status = status_clone.lock().unwrap();
@@ -731,9 +773,9 @@ pub fn run() {
                                         let obs_client_clone = obs_ws_client_clone.clone();
                                         tauri::async_runtime::spawn(async move {
                                             if let Err(e) = send_obs_command_wrapper(obs_client_clone, "StartRecord").await {
-                                                eprintln!("Failed to start OBS recording: {}", e);
+                                                error!("Failed to start OBS recording: {}", e);
                                             } else {
-                                                println!("Started OBS recording");
+                                                info!("Started OBS recording");
                                             }
                                         });
                                     }
@@ -743,9 +785,9 @@ pub fn run() {
                                             let ffmpeg_process_clone = ffmpeg_process_clone.clone();
                                             async move {
                                                 if let Err(e) = ffmpeg_clone.lock().await.start(ffmpeg_process_clone).await {
-                                                    eprintln!("Failed to start ffmpeg recording: {}", e);
+                                                    error!("Failed to start ffmpeg recording: {}", e);
                                                 } else {
-                                                    println!("Started ffmpeg recording");
+                                                    info!("Started ffmpeg recording");
                                                 }
                                             }
                                         });
@@ -755,7 +797,7 @@ pub fn run() {
 
                             // ゲーム終了時にOBSかffmpegの録画を停止
                             "GameEnd" => {
-                                println!("Game ended at {}", event.EventTime);
+                                info!("Game ended at {}", event.EventTime);
 
                                 // ゲーム状態を更新
                                 let mut status = status_clone.lock().unwrap();
@@ -769,9 +811,9 @@ pub fn run() {
                                         let obs_client_clone = obs_ws_client_clone.clone();
                                         tauri::async_runtime::spawn(async move {
                                             if let Err(e) = send_obs_command_wrapper(obs_client_clone, "StopRecord").await {
-                                                eprintln!("Failed to stop OBS recording: {}", e);
+                                                error!("Failed to stop OBS recording: {}", e);
                                             } else {
-                                                println!("Stopped OBS recording");
+                                                info!("Stopped OBS recording");
                                             }
                                         });
                                     }
@@ -779,16 +821,16 @@ pub fn run() {
                                         let ffmpeg_clone = ffmpeg_process_clone.clone();
                                         tauri::async_runtime::spawn(async move {
                                             if let Err(e) = ffmpeg_clone.lock().await.stop().await {
-                                                eprintln!("Failed to stop ffmpeg recording: {}", e);
+                                                error!("Failed to stop ffmpeg recording: {}", e);
                                             } else {
-                                                println!("Stopped ffmpeg recording");
+                                                info!("Stopped ffmpeg recording");
                                             }
                                         });
                                     }
                                 }
                             }
                             _ => {
-                                println!("Unhandled event: {} at {}", event.EventName, event.EventTime);
+                                info!("Unhandled event: {} at {}", event.EventName, event.EventTime);
                             }
                         }
                     }
@@ -822,7 +864,7 @@ where
     let mut seen_event_ids: HashSet<i64> = HashSet::new();
     let mut pending_events: Vec<(LolEvent, f64)> = Vec::new();
 
-    println!("Starting LoL event polling...");
+    info!("Starting LoL event polling...");
 
     loop {
         let delay_secs = {
@@ -858,13 +900,13 @@ where
                             });
 
                             if !ready_events.is_empty() {
-                                println!("Delayed events triggered: {}", ready_events.len());
+                                info!("Delayed events triggered: {}", ready_events.len());
                                 callback(&all_data, ready_events);
                             }
 
                         }
                         Err(e) => {
-                            eprintln!("Failed to parse AllGameData from response: {}", e);
+                            error!("Failed to parse AllGameData from response: {}", e);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- introduce `log` and `flexi_logger`
- initialise logging when the Tauri app starts
- send log output to both the console and a log file
- replace debug `println!` calls with `info!`/`error!` macros

## Testing
- `cargo check` *(fails: glib-sys build script missing system libraries)*

------
https://chatgpt.com/codex/tasks/task_e_6854a9e0d2b4832cb9ad66ba430965e9