### PR TITLE
Add mock notification feature

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2104,6 +2104,7 @@ dependencies = [
  "flexi_logger",
  "futures-util",
  "log",
+ "notify-rust",
  "reqwest",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ dirs = "6.0.0"
 tauri-plugin-fs = "2.3.0"
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
+notify-rust = "4"
 log = "0.4"
 flexi_logger = "0.27"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -95,6 +95,8 @@ pub fn show_notification_no_handle(title: &str, body: &str) -> Result<(), String
 
 fn show_notification_impl(app: Option<tauri::AppHandle>, title: &str, body: &str) -> Result<(), String> {
     if let Some(handle) = app {
+
+        info!("Showing notification: {} - {}", title, body);
         handle
             .notification()
             .builder()
@@ -103,6 +105,8 @@ fn show_notification_impl(app: Option<tauri::AppHandle>, title: &str, body: &str
             .show()
             .map_err(|e| e.to_string())
     } else {
+
+        info!("Showing notification without AppHandle: {} - {}", title, body);
         notify_rust::Notification::new()
             .summary(title)
             .body(body)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,44 @@ fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+/// Shows a desktop notification.
+///
+/// When called as a Tauri command the [`AppHandle`] parameter is automatically
+/// supplied by the runtime so the JS side does not pass it.
+///
+/// If you want to trigger a notification from Rust code where the `AppHandle`
+/// is not available, call [`show_notification_no_handle`] instead.
+#[tauri::command]
+fn show_notification(app: tauri::AppHandle, title: String, body: String) -> Result<(), String> {
+    show_notification_impl(Some(app), &title, &body)
+}
+
+/// Alternative notification function that does not require an [`AppHandle`].
+/// This falls back to `notify_rust` so the icon may differ from the Tauri
+/// plugin version.
+pub fn show_notification_no_handle(title: &str, body: &str) -> Result<(), String> {
+    show_notification_impl(None, title, body)
+}
+
+fn show_notification_impl(app: Option<tauri::AppHandle>, title: &str, body: &str) -> Result<(), String> {
+    if let Some(handle) = app {
+        handle
+            .notification()
+            .builder()
+            .title(title)
+            .body(body)
+            .show()
+            .map_err(|e| e.to_string())
+    } else {
+        notify_rust::Notification::new()
+            .summary(title)
+            .body(body)
+            .show()
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+}
+
 #[tauri::command]
 fn get_status(state: tauri::State<AppStatusState>) -> AppStatus {
     state.0.lock().unwrap().clone()
@@ -617,7 +655,8 @@ pub fn run() {
             get_clip_metadata,
             load_settings_cmd,
             save_settings_cmd,
-            greet])
+            greet,
+            show_notification])
         .setup( |_app| {
 
             let config_path = _app.path().config_dir().unwrap().join("settings.json");

--- a/src/index.html
+++ b/src/index.html
@@ -22,6 +22,9 @@
       <main class="container py-4 app-container overscroll-none">
         <h1 class="mb-4 text-center">LoL OBS Clip Tool</h1>
         <p class="text-center">Select OBS mode from the navigation bar. Saved videos appear under Videos.</p>
+        <div class="text-center mt-6">
+          <button id="notifyTestBtn" class="px-4 py-2 border border-blue-600 rounded text-blue-600">通知テスト</button>
+        </div>
       </main>
     </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,15 @@
 // エントリーポイント用のJSファイル
-// 現時点では特別な処理をしていないが、将来的な拡張を見据えて残してある
+// 通知テストボタンのクリックで Rust 側コマンドを呼び出すサンプル
+const { invoke } = window.__TAURI__.core;
+
 window.addEventListener("DOMContentLoaded", () => {
-  // 動的な処理が必要になった場合はここに追記する
-  // 例: 初期化コードやイベントリスナー登録
+  const btn = document.getElementById("notifyTestBtn");
+  if (btn) {
+    btn.addEventListener("click", () => {
+      invoke("show_notification", {
+        title: "テスト通知",
+        body: "JS から呼び出しました",
+      });
+    });
+  }
 }); // DOM 準備完了後に実行


### PR DESCRIPTION
## Summary
- add a show_notification command in Rust side
- trigger the notification from JS when clicking `通知テスト` on the home page
- clarify via code comment that `AppHandle` is injected automatically
- support notifications when `AppHandle` isn't available

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6854b3df456c832cb7acbcbd2c7366b8