### PR TITLE
Add audio playback module

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -1,0 +1,13 @@
+export function playAudio(path) {
+  const url = window.__TAURI__.core.convertFileSrc(path);
+  const audio = new Audio(url);
+  audio.play().catch((e) => console.error('Audio play failed', e));
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  window.__TAURI__.event.listen('play-sound', (e) => {
+    if (typeof e.payload === 'string') {
+      playAudio(e.payload);
+    }
+  });
+});

--- a/src/ffmpeg.html
+++ b/src/ffmpeg.html
@@ -6,6 +6,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FFmpeg Mode - LoL Clip Tool</title>
+    <script type="module" src="/audio.js" defer></script>
     <script type="module" src="/settings.js" defer></script>
     <script type="module" src="/debug.js" defer></script>
   </head>

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LoL Clip Tool</title>
+    <script type="module" src="/audio.js" defer></script>
     <script type="module" src="/main.js" defer></script>
     <script type="module" src="/debug.js" defer></script>
   </head>

--- a/src/obs.html
+++ b/src/obs.html
@@ -6,6 +6,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OBS Mode - LoL Clip Tool</title>
+    <script type="module" src="/audio.js" defer></script>
     <script type="module" src="/settings.js" defer></script>
     <script type="module" src="/debug.js" defer></script>
   </head>

--- a/src/video.html
+++ b/src/video.html
@@ -11,6 +11,7 @@
       href="https://vjs.zencdn.net/8.3.0/video-js.min.css"
     />
     <script src="https://vjs.zencdn.net/8.3.0/video.min.js"></script>
+    <script type="module" src="/audio.js" defer></script>
     <script type="module" src="/viewer.js" defer></script>
     <script type="module" src="/debug.js" defer></script>
   </head>

--- a/src/videos.html
+++ b/src/videos.html
@@ -6,6 +6,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Saved Videos - LoL Clip Tool</title>
+    <script type="module" src="/audio.js" defer></script>
     <script type="module" src="/videos.js" defer></script>
     <script type="module" src="/debug.js" defer></script>
   </head>


### PR DESCRIPTION
## Summary
- create `audio.js` to play audio via browser
- listen for `play-sound` event to trigger audio playback
- include `audio.js` in all HTML pages

## Testing
- `pnpm install`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 pkg-config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854b41af2fc832c85d9bd479579fe25