### PR TITLE
Show live LoL player info

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -668,6 +668,8 @@ async fn list_ffmpeg_devices() -> Result<DeviceList, String> {
 /// アプリ状態を共有するためのラッパー
 struct AppStatusState(Arc<Mutex<AppStatus>>);
 /// 最新の LoL ゲームデータを保持するためのラッパー
+
+#[derive(Clone)]
 struct LolDataState(Arc<Mutex<Option<AllGameData>>>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,7 +21,7 @@ mod settings; // 設定関連 // SQLite アクセス
 
 use db::{cleanup_orphan_clips, get_clip_events, init_db, list_clips, DbPath};
 use ffmpeg::{write_clip_metadata, FfmpegProcess, FfmpegState, SharedFfmpegProcess};
-use lol::{AllGameData, LolEvent};
+use lol::{AllGameData, LolEvent, Player};
 use obs::{send_obs_command_wrapper, set_record_directory, ObsWsState, SharedObsWsClient};
 use settings::{load_settings, save_settings, AppSettings, SettingsPath, SettingsState}; // DB 操作用
 
@@ -67,6 +67,12 @@ struct AppStatus {
     recording_mode: RecordingMode,
     is_recording: bool,
     replay_buffer_running: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GamePlayer {
+    name: String,
+    champion: String,
 }
 
 #[tauri::command]
@@ -132,6 +138,22 @@ fn log_message(level: Option<String>, message: String) -> Result<(), String> {
 #[tauri::command]
 fn get_status(state: tauri::State<AppStatusState>) -> AppStatus {
     state.0.lock().unwrap().clone()
+}
+
+#[tauri::command]
+fn get_current_players(state: tauri::State<LolDataState>) -> Vec<GamePlayer> {
+    let lock = state.0.lock().unwrap();
+    if let Some(ref data) = *lock {
+        data.allPlayers
+            .iter()
+            .map(|p| GamePlayer {
+                name: p.summonerName.clone(),
+                champion: p.championName.clone(),
+            })
+            .collect()
+    } else {
+        Vec::new()
+    }
 }
 
 #[tauri::command]
@@ -645,6 +667,8 @@ async fn list_ffmpeg_devices() -> Result<DeviceList, String> {
 
 /// アプリ状態を共有するためのラッパー
 struct AppStatusState(Arc<Mutex<AppStatus>>);
+/// 最新の LoL ゲームデータを保持するためのラッパー
+struct LolDataState(Arc<Mutex<Option<AllGameData>>>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -672,6 +696,7 @@ pub fn run() {
             get_clip_metadata,
             load_settings_cmd,
             save_settings_cmd,
+            get_current_players,
             greet,
             show_notification,
             log_message])
@@ -704,6 +729,8 @@ pub fn run() {
             };
             let status = Arc::new(Mutex::new(status));
 
+            let lol_data_state = LolDataState(Arc::new(Mutex::new(None)));
+
             let ffmpeg_process: SharedFfmpegProcess = Arc::new(AsyncMutex::new(ffmpeg_proc));
             let obs_ws_client: SharedObsWsClient = Arc::new(Mutex::new(None));
             let status_clone = status.clone();
@@ -717,6 +744,7 @@ pub fn run() {
             _app.manage(settings_state);
             _app.manage(settings_path_state);
             _app.manage(db_state.clone());
+            _app.manage(lol_data_state.clone());
 
             let dir = settings.save_dir.clone();
             let obs_ws_client_clone2 = obs_ws_client.clone();
@@ -727,9 +755,14 @@ pub fn run() {
             let obs_ws_client_clone = obs_ws_client.clone();
             let ffmpeg_process_clone = ffmpeg_process.clone();
             let db_path_clone = db_state.clone();
+            let lol_data_state_clone = lol_data_state.clone();
 
             tauri::async_runtime::spawn(async move {
                 poll_lol_events(settings_state_clone2, move |all_data: &AllGameData, new_events: Vec<LolEvent>| {
+                    {
+                        let mut lock = lol_data_state_clone.0.lock().unwrap();
+                        *lock = Some(all_data.clone());
+                    }
                     let mut status = status_clone.lock().unwrap();
                     if status.game_state == GameState::NotStarted {
                         status.game_state = GameState::InProgress;

--- a/src/ffmpeg.html
+++ b/src/ffmpeg.html
@@ -9,6 +9,7 @@
     <script type="module" src="/audio.js" defer></script>
     <script type="module" src="/settings.js" defer></script>
     <script type="module" src="/debug.js" defer></script>
+    <script type="module" src="/gameinfo.js" defer></script>
   </head>
 
     <body class="h-screen flex flex-col overscroll-none">
@@ -27,9 +28,9 @@
 
       <div class="flex flex-col md:flex-row w-full h-full gap-6">
         <div class="md:w-1/2 order-2 md:order-1 flex flex-col">
-          <div class="log-container">
-            <h2 class="h5 mb-3">📜 ゲームイベントログ</h2>
-            <ul id="eventLog" class="list-unstyled"></ul>
+          <div class="player-panel">
+            <h2 class="h5 mb-3">👥 プレイヤー</h2>
+            <ul id="playerList" class="list-disc list-inside"></ul>
           </div>
         </div>
 
@@ -78,12 +79,13 @@
               </div>
             </div>
             <button class="px-4 py-2 mr-2 border border-green-600 text-green-600 rounded" id="btnReplayStart">開始</button>
-            <button class="px-4 py-2 mr-2 border border-yellow-500 text-yellow-500 rounded" id="btnReplayStop">停止</button>
-            <button class="px-4 py-2 border border-teal-500 text-teal-500 rounded" id="btnReplaySave">保存</button>
-          </div>
+          <button class="px-4 py-2 mr-2 border border-yellow-500 text-yellow-500 rounded" id="btnReplayStop">停止</button>
+          <button class="px-4 py-2 border border-teal-500 text-teal-500 rounded" id="btnReplaySave">保存</button>
+        </div>
 
-          <div class="button-group mb-4">
-            <h2 class="h5 mb-3">🛠 ユーティリティ</h2>
+
+        <div class="button-group mb-4">
+          <h2 class="h5 mb-3">🛠 ユーティリティ</h2>
             <div class="flex mb-2 space-x-2">
               <input class="border border-gray-600 bg-gray-800 text-gray-100 rounded p-1 flex-grow" id="saveDirInput" />
               <button class="px-2 py-1 border border-gray-500 text-gray-700 rounded" id="chooseDirBtn">選択</button>

--- a/src/gameinfo.js
+++ b/src/gameinfo.js
@@ -1,0 +1,22 @@
+const { invoke } = window.__TAURI__.core;
+
+async function refreshPlayers() {
+  try {
+    const players = await invoke('get_current_players');
+    const list = document.getElementById('playerList');
+    if (!list) return;
+    list.innerHTML = '';
+    players.forEach((p) => {
+      const li = document.createElement('li');
+      li.textContent = `${p.name} (${p.champion})`;
+      list.appendChild(li);
+    });
+  } catch (e) {
+    console.error('Failed to fetch players', e);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  refreshPlayers();
+  setInterval(refreshPlayers, 2000);
+});

--- a/src/obs.html
+++ b/src/obs.html
@@ -9,6 +9,7 @@
     <script type="module" src="/audio.js" defer></script>
     <script type="module" src="/settings.js" defer></script>
     <script type="module" src="/debug.js" defer></script>
+    <script type="module" src="/gameinfo.js" defer></script>
   </head>
 
   <body class="h-screen flex flex-col overscroll-none">
@@ -40,6 +41,11 @@
           <button class="px-4 py-2 mr-2 border border-green-600 text-green-600 rounded" id="btnReplayStart">開始</button>
           <button class="px-4 py-2 mr-2 border border-yellow-500 text-yellow-500 rounded" id="btnReplayStop">停止</button>
           <button class="px-4 py-2 border border-teal-500 text-teal-500 rounded" id="btnReplaySave">保存</button>
+        </div>
+
+        <div class="player-panel mb-4">
+          <h2 class="h5 mb-3">👥 プレイヤー</h2>
+          <ul id="playerList" class="list-disc list-inside"></ul>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- expose latest game data via Tauri state
- add `get_current_players` command
- update OBS/FFmpeg pages to list players
- poll players with new `gameinfo.js`
- replace old event log panel with the player list

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: gobject-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e6397e74832cb56e48bc2a9b81f5